### PR TITLE
feat(client): core HTTP client for LPDB v3

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -9,9 +9,6 @@ name = "python"
 runtime_version = "3.x.x"
 max_line_length = 120
 
-[analyzers.exclude_patterns]
-# __init__.py re-exports are intentional (declared in __all__)
-PY-W2000 = ["**/__init__.py"]
 
 [[analyzers]]
 name = "test-coverage"

--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -9,6 +9,10 @@ name = "python"
 runtime_version = "3.x.x"
 max_line_length = 120
 
+[analyzers.exclude_patterns]
+# __init__.py re-exports are intentional (declared in __all__)
+PY-W2000 = ["**/__init__.py"]
+
 [[analyzers]]
 name = "test-coverage"
 enabled = true

--- a/README.md
+++ b/README.md
@@ -23,8 +23,11 @@ Built with [`httpx`](https://www.python-httpx.org/) and [`pydantic`](https://doc
 
 ```
 liquipydia/
-├── __init__.py     # Package exports, version
-└── py.typed        # PEP 561 type marker
+├── __init__.py       # Package exports, version
+├── _client.py        # Core HTTP client (LiquipediaClient)
+├── _exceptions.py    # Exception hierarchy
+├── _response.py      # API response wrapper
+└── py.typed          # PEP 561 type marker
 ```
 
 ## API Access
@@ -50,8 +53,20 @@ pip install git+https://github.com/Dyl-M/liquipydia.git
 ## Quick Start
 
 ```python
-# Coming soon — see the Roadmap for progress.
+from liquipydia import LiquipediaClient
+
+with LiquipediaClient("my-app", api_key="your-api-key") as client:
+    # Low-level request (resource helpers coming in v0.0.3)
+    response = client._get("player", {"wiki": "dota2", "limit": 5})
+    for player in response.result:
+        print(player)
+
+    # Automatic pagination
+    for match in client.paginate("match", {"wiki": "counterstrike"}, page_size=100, max_results=500):
+        print(match)
 ```
+
+> The API key can also be set via the `LIQUIPEDIA_API_KEY` environment variable.
 
 ## Development
 

--- a/_docs/ROADMAP.md
+++ b/_docs/ROADMAP.md
@@ -17,18 +17,18 @@ Set up the project structure, tooling, and CI before writing any library code.
 
 The foundation everything else depends on. Handles transport, auth, compliance with Liquipedia API constraints.
 
-- [ ] `LiquipediaClient` class wrapping `httpx.Client`
-    - Constructor: `app_name` (required), `api_key` (optional, from param or env var)
+- [x] `LiquipediaClient` class wrapping `httpx.Client`
+    - Constructor: `app_name` (required), `api_key` (optional, from param or env var `LIQUIPEDIA_API_KEY`)
     - Custom `User-Agent` header: `{app_name} (via liquipydia/{version})`
     - `Accept-Encoding: gzip` by default
     - Session reuse (single `httpx.Client` instance)
     - Context manager support (`with LiquipediaClient(...) as client:`)
-- [ ] Base URL configuration (`https://api.liquipedia.net/api/v3/`)
-- [ ] Rate limiting (respect Liquipedia ToS — backoff on 429)
-- [ ] Error handling: map HTTP status codes to typed exceptions (`LiquipediaError`, `RateLimitError`, `AuthError`,
-  `NotFoundError`)
-- [ ] Pagination helper (LPDB uses `offset` + `limit`)
-- [ ] Response envelope parsing (extract `result` from API response)
+- [x] Base URL configuration (`https://api.liquipedia.net/api/v3/`)
+- [x] Rate limiting (truncated exponential backoff on 429, respects `Retry-After` header)
+- [x] Error handling: map HTTP status codes to typed exceptions (`LiquipediaError`, `RateLimitError`, `AuthError`,
+  `NotFoundError`, `ApiError`)
+- [x] Pagination helper (`paginate()` generator using `offset` + `limit`)
+- [x] Response envelope parsing (`ApiResponse` dataclass — extracts `result` and `warning` from API response)
 
 ## v0.0.3 — Resource layer (16 data types)
 

--- a/_tests/test_client.py
+++ b/_tests/test_client.py
@@ -77,7 +77,8 @@ class TestConstructor:
         request = respx.calls.last.request
         assert "gzip" in request.headers["Accept-Encoding"]
 
-    def test_api_key_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    @staticmethod
+    def test_api_key_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
         """Verify API key falls back to LIQUIPEDIA_API_KEY env var."""
         monkeypatch.setenv("LIQUIPEDIA_API_KEY", "env-key")
 
@@ -92,13 +93,15 @@ class TestConstructor:
 class TestContextManager:
     """Tests for context manager protocol."""
 
-    def test_enter_returns_self(self) -> None:
+    @staticmethod
+    def test_enter_returns_self() -> None:
         """Verify __enter__ returns the client instance."""
         client = _make_client()
         assert client.__enter__() is client
         client.close()
 
-    def test_exit_closes_client(self) -> None:
+    @staticmethod
+    def test_exit_closes_client() -> None:
         """Verify __exit__ closes the HTTP session."""
         client = _make_client()
 

--- a/_tests/test_client.py
+++ b/_tests/test_client.py
@@ -1,0 +1,291 @@
+"""Tests for the liquipydia core client."""
+
+import httpx
+import pytest
+import respx
+
+from liquipydia import (
+    ApiError,
+    AuthError,
+    LiquipediaClient,
+    LiquipediaError,
+    NotFoundError,
+    RateLimitError,
+    __version__,
+)
+
+BASE_URL = "https://api.liquipedia.net/api/v3/"
+
+# === Helpers ===
+
+
+def _make_client(**kwargs: object) -> LiquipediaClient:
+    """Create a client with defaults suitable for testing."""
+    defaults: dict[str, object] = {"app_name": "test-app", "api_key": "test-key", "timeout": 5.0}
+    defaults.update(kwargs)
+    return LiquipediaClient(**defaults)  # type: ignore[arg-type]
+
+
+# === Constructor & Headers ===
+
+
+class TestConstructor:
+    """Tests for LiquipediaClient construction and header setup."""
+
+    @respx.mock
+    def test_user_agent_header(self) -> None:
+        """Verify User-Agent header is set correctly."""
+        respx.get(f"{BASE_URL}player").mock(return_value=httpx.Response(200, json={"result": []}))
+
+        with _make_client(app_name="my-app") as client:
+            client._get("player", {"wiki": "dota2"})
+
+        request = respx.calls.last.request
+        assert request.headers["User-Agent"] == f"my-app (via liquipydia/{__version__})"
+
+    @respx.mock
+    def test_authorization_header_present(self) -> None:
+        """Verify Authorization header is set when API key is provided."""
+        respx.get(f"{BASE_URL}player").mock(return_value=httpx.Response(200, json={"result": []}))
+
+        with _make_client(api_key="secret-key") as client:
+            client._get("player", {"wiki": "dota2"})
+
+        request = respx.calls.last.request
+        assert request.headers["Authorization"] == "Apikey secret-key"
+
+    @respx.mock
+    def test_authorization_header_absent(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Verify Authorization header is absent when no API key is provided."""
+        monkeypatch.delenv("LIQUIPEDIA_API_KEY", raising=False)
+        respx.get(f"{BASE_URL}player").mock(return_value=httpx.Response(200, json={"result": []}))
+
+        with LiquipediaClient("test-app", api_key=None) as client:
+            client._get("player", {"wiki": "dota2"})
+
+        request = respx.calls.last.request
+        assert "Authorization" not in request.headers
+
+    @respx.mock
+    def test_accept_encoding_header(self) -> None:
+        """Verify Accept-Encoding: gzip is set."""
+        respx.get(f"{BASE_URL}player").mock(return_value=httpx.Response(200, json={"result": []}))
+
+        with _make_client() as client:
+            client._get("player", {"wiki": "dota2"})
+
+        request = respx.calls.last.request
+        assert "gzip" in request.headers["Accept-Encoding"]
+
+    def test_api_key_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Verify API key falls back to LIQUIPEDIA_API_KEY env var."""
+        monkeypatch.setenv("LIQUIPEDIA_API_KEY", "env-key")
+
+        with LiquipediaClient("test-app") as client:
+            auth = client._http.headers.get("Authorization")
+            assert auth == "Apikey env-key"
+
+
+# === Context Manager ===
+
+
+class TestContextManager:
+    """Tests for context manager protocol."""
+
+    def test_enter_returns_self(self) -> None:
+        """Verify __enter__ returns the client instance."""
+        client = _make_client()
+        assert client.__enter__() is client
+        client.close()
+
+    def test_exit_closes_client(self) -> None:
+        """Verify __exit__ closes the HTTP session."""
+        client = _make_client()
+
+        with client:
+            pass
+
+        assert client._http.is_closed
+
+
+# === Response Parsing ===
+
+
+class TestParseResponse:
+    """Tests for _parse_response behavior."""
+
+    @respx.mock
+    def test_successful_response(self) -> None:
+        """Verify successful response returns result from API body."""
+        respx.get(f"{BASE_URL}player").mock(return_value=httpx.Response(200, json={"result": [{"name": "Miracle-"}]}))
+
+        with _make_client() as client:
+            response = client._get("player", {"wiki": "dota2"})
+
+        assert response.result == [{"name": "Miracle-"}]
+
+    @respx.mock
+    def test_response_with_warnings(self) -> None:
+        """Verify warnings from API body are forwarded."""
+        respx.get(f"{BASE_URL}player").mock(
+            return_value=httpx.Response(
+                200,
+                json={"result": [], "warning": ["deprecated field"]},
+            )
+        )
+
+        with _make_client() as client:
+            response = client._get("player", {"wiki": "dota2"})
+
+        assert response.warnings == ["deprecated field"]
+
+    @respx.mock
+    def test_api_body_error(self) -> None:
+        """Verify API body errors raise ApiError."""
+        respx.get(f"{BASE_URL}player").mock(
+            return_value=httpx.Response(200, json={"result": [], "error": ["unknown wiki"]})
+        )
+
+        with _make_client() as client, pytest.raises(ApiError, match="unknown wiki"):
+            client._get("player", {"wiki": "badwiki"})
+
+
+# === HTTP Error Handling ===
+
+
+class TestHttpErrors:
+    """Tests for HTTP status code error mapping."""
+
+    @respx.mock
+    def test_403_raises_auth_error(self) -> None:
+        """Verify HTTP 403 raises AuthError."""
+        respx.get(f"{BASE_URL}player").mock(return_value=httpx.Response(403))
+
+        with _make_client() as client, pytest.raises(AuthError):
+            client._get("player", {"wiki": "dota2"})
+
+    @respx.mock
+    def test_404_raises_not_found_error(self) -> None:
+        """Verify HTTP 404 raises NotFoundError."""
+        respx.get(f"{BASE_URL}player").mock(return_value=httpx.Response(404))
+
+        with _make_client() as client, pytest.raises(NotFoundError):
+            client._get("player", {"wiki": "dota2"})
+
+    @respx.mock
+    def test_500_raises_liquipedia_error(self) -> None:
+        """Verify HTTP 500 raises LiquipediaError."""
+        respx.get(f"{BASE_URL}player").mock(return_value=httpx.Response(500, text="Internal Server Error"))
+
+        with _make_client() as client, pytest.raises(LiquipediaError, match="HTTP 500"):
+            client._get("player", {"wiki": "dota2"})
+
+
+# === Rate Limiting ===
+
+
+class TestRateLimiting:
+    """Tests for 429 retry behavior."""
+
+    @respx.mock
+    def test_429_retries_and_succeeds(self) -> None:
+        """Verify client retries on 429 and succeeds when the next attempt works."""
+        route = respx.get(f"{BASE_URL}player")
+        route.side_effect = [
+            httpx.Response(429, headers={"Retry-After": "0"}),
+            httpx.Response(200, json={"result": [{"id": 1}]}),
+        ]
+
+        with _make_client(max_retries=3, retry_backoff_factor=0.0) as client:
+            response = client._get("player", {"wiki": "dota2"})
+
+        assert response.result == [{"id": 1}]
+        assert route.call_count == 2
+
+    @respx.mock
+    def test_429_exhausts_retries(self) -> None:
+        """Verify RateLimitError is raised after max retries."""
+        respx.get(f"{BASE_URL}player").mock(return_value=httpx.Response(429, headers={"Retry-After": "0"}))
+
+        with _make_client(max_retries=2, retry_backoff_factor=0.0) as client, pytest.raises(RateLimitError):
+            client._get("player", {"wiki": "dota2"})
+
+    @respx.mock
+    def test_429_uses_retry_after_header(self) -> None:
+        """Verify RateLimitError carries the Retry-After value."""
+        respx.get(f"{BASE_URL}player").mock(return_value=httpx.Response(429, headers={"Retry-After": "42"}))
+
+        with _make_client(max_retries=0) as client, pytest.raises(RateLimitError) as exc_info:
+            client._get("player", {"wiki": "dota2"})
+
+        assert exc_info.value.retry_after == 42
+
+    @respx.mock
+    def test_429_non_numeric_retry_after(self) -> None:
+        """Verify non-numeric Retry-After header falls back to computed backoff."""
+        route = respx.get(f"{BASE_URL}player")
+        route.side_effect = [
+            httpx.Response(429, headers={"Retry-After": "not-a-number"}),
+            httpx.Response(200, json={"result": [{"id": 1}]}),
+        ]
+
+        with _make_client(max_retries=3, retry_backoff_factor=0.0) as client:
+            response = client._get("player", {"wiki": "dota2"})
+
+        assert response.result == [{"id": 1}]
+
+
+# === Pagination ===
+
+
+class TestPagination:
+    """Tests for the paginate method."""
+
+    @respx.mock
+    def test_paginate_single_page(self) -> None:
+        """Verify pagination stops when a page returns fewer records than page_size."""
+        respx.get(f"{BASE_URL}player").mock(return_value=httpx.Response(200, json={"result": [{"id": 1}, {"id": 2}]}))
+
+        with _make_client() as client:
+            records = list(client.paginate("player", {"wiki": "dota2"}, page_size=10))
+
+        assert records == [{"id": 1}, {"id": 2}]
+
+    @respx.mock
+    def test_paginate_multiple_pages(self) -> None:
+        """Verify pagination fetches multiple pages."""
+        route = respx.get(f"{BASE_URL}player")
+        route.side_effect = [
+            httpx.Response(200, json={"result": [{"id": 1}, {"id": 2}]}),
+            httpx.Response(200, json={"result": [{"id": 3}]}),
+        ]
+
+        with _make_client() as client:
+            records = list(client.paginate("player", {"wiki": "dota2"}, page_size=2))
+
+        assert records == [{"id": 1}, {"id": 2}, {"id": 3}]
+        assert route.call_count == 2
+
+    @respx.mock
+    def test_paginate_max_results(self) -> None:
+        """Verify pagination stops at max_results."""
+        respx.get(f"{BASE_URL}player").mock(
+            return_value=httpx.Response(200, json={"result": [{"id": i} for i in range(10)]})
+        )
+
+        with _make_client() as client:
+            records = list(client.paginate("player", {"wiki": "dota2"}, page_size=10, max_results=3))
+
+        assert len(records) == 3
+
+    @respx.mock
+    def test_paginate_does_not_mutate_params(self) -> None:
+        """Verify pagination does not mutate the caller's params dict."""
+        respx.get(f"{BASE_URL}player").mock(return_value=httpx.Response(200, json={"result": []}))
+
+        params = {"wiki": "dota2"}
+
+        with _make_client() as client:
+            list(client.paginate("player", params, page_size=10))
+
+        assert params == {"wiki": "dota2"}

--- a/_tests/test_exceptions.py
+++ b/_tests/test_exceptions.py
@@ -1,0 +1,48 @@
+"""Tests for the liquipydia exception hierarchy."""
+
+from liquipydia import ApiError, AuthError, LiquipediaError, NotFoundError, RateLimitError
+
+
+def test_liquipedia_error_is_exception() -> None:
+    """Verify that LiquipediaError inherits from Exception."""
+    assert issubclass(LiquipediaError, Exception)
+
+
+def test_liquipedia_error_message() -> None:
+    """Verify that LiquipediaError stores its message."""
+    err = LiquipediaError("something went wrong")
+    assert err.message == "something went wrong"
+    assert str(err) == "something went wrong"
+
+
+def test_auth_error_is_liquipedia_error() -> None:
+    """Verify that AuthError is a subclass of LiquipediaError."""
+    assert issubclass(AuthError, LiquipediaError)
+
+
+def test_not_found_error_is_liquipedia_error() -> None:
+    """Verify that NotFoundError is a subclass of LiquipediaError."""
+    assert issubclass(NotFoundError, LiquipediaError)
+
+
+def test_rate_limit_error_is_liquipedia_error() -> None:
+    """Verify that RateLimitError is a subclass of LiquipediaError."""
+    assert issubclass(RateLimitError, LiquipediaError)
+
+
+def test_rate_limit_error_retry_after() -> None:
+    """Verify that RateLimitError carries retry_after."""
+    err = RateLimitError("too many requests", retry_after=30)
+    assert err.retry_after == 30
+    assert err.message == "too many requests"
+
+
+def test_rate_limit_error_retry_after_default() -> None:
+    """Verify that RateLimitError defaults retry_after to None."""
+    err = RateLimitError("too many requests")
+    assert err.retry_after is None
+
+
+def test_api_error_is_liquipedia_error() -> None:
+    """Verify that ApiError is a subclass of LiquipediaError."""
+    assert issubclass(ApiError, LiquipediaError)

--- a/_tests/test_init.py
+++ b/_tests/test_init.py
@@ -10,7 +10,7 @@ def test_version_is_string() -> None:
 
 def test_version_value() -> None:
     """Verify that __version__ matches the expected value."""
-    assert __version__ == "0.0.1"
+    assert __version__ == "0.0.2"
 
 
 def test_author() -> None:

--- a/_tests/test_response.py
+++ b/_tests/test_response.py
@@ -1,0 +1,32 @@
+"""Tests for the ApiResponse dataclass."""
+
+from liquipydia import ApiResponse
+
+
+def test_api_response_stores_result() -> None:
+    """Verify that ApiResponse stores the result list."""
+    resp = ApiResponse(result=[{"id": 1}], warnings=[])
+    assert resp.result == [{"id": 1}]
+
+
+def test_api_response_stores_warnings() -> None:
+    """Verify that ApiResponse stores warnings."""
+    resp = ApiResponse(result=[], warnings=["deprecated field"])
+    assert resp.warnings == ["deprecated field"]
+
+
+def test_api_response_empty_defaults() -> None:
+    """Verify that ApiResponse works with empty lists."""
+    resp = ApiResponse(result=[], warnings=[])
+    assert resp.result == []
+    assert resp.warnings == []
+
+
+def test_api_response_is_frozen() -> None:
+    """Verify that ApiResponse is immutable."""
+    import pytest
+
+    resp = ApiResponse(result=[], warnings=[])
+    with pytest.raises(AttributeError):
+        # noinspection PyDataclass
+        resp.result = [{"id": 1}]  # type: ignore[misc]

--- a/liquipydia/__init__.py
+++ b/liquipydia/__init__.py
@@ -1,9 +1,25 @@
 """Python client library for the Liquipedia API (LPDB v3)."""
 
-__version__ = "0.0.1"
+# Local
+from liquipydia._client import LiquipediaClient
+from liquipydia._exceptions import ApiError, AuthError, LiquipediaError, NotFoundError, RateLimitError
+from liquipydia._response import ApiResponse
+
+__version__ = "0.0.2"
 __author__ = "Dylan Monfret"
 
 __all__: list[str] = [
+    # Metadata
     "__author__",
     "__version__",
+    # Client
+    "LiquipediaClient",
+    # Response
+    "ApiResponse",
+    # Exceptions
+    "ApiError",
+    "AuthError",
+    "LiquipediaError",
+    "NotFoundError",
+    "RateLimitError",
 ]

--- a/liquipydia/__init__.py
+++ b/liquipydia/__init__.py
@@ -1,13 +1,15 @@
 """Python client library for the Liquipedia API (LPDB v3)."""
 
-# Local (explicit re-exports)
-from liquipydia._client import LiquipediaClient as LiquipediaClient
-from liquipydia._exceptions import ApiError as ApiError
-from liquipydia._exceptions import AuthError as AuthError
-from liquipydia._exceptions import LiquipediaError as LiquipediaError
-from liquipydia._exceptions import NotFoundError as NotFoundError
-from liquipydia._exceptions import RateLimitError as RateLimitError
-from liquipydia._response import ApiResponse as ApiResponse
+# Local
+from liquipydia._client import LiquipediaClient  # skipcq: PY-W2000
+from liquipydia._exceptions import (  # skipcq: PY-W2000
+    ApiError,
+    AuthError,
+    LiquipediaError,
+    NotFoundError,
+    RateLimitError,
+)
+from liquipydia._response import ApiResponse  # skipcq: PY-W2000
 
 __version__ = "0.0.2"
 __author__ = "Dylan Monfret"

--- a/liquipydia/__init__.py
+++ b/liquipydia/__init__.py
@@ -1,9 +1,13 @@
 """Python client library for the Liquipedia API (LPDB v3)."""
 
-# Local
-from liquipydia._client import LiquipediaClient
-from liquipydia._exceptions import ApiError, AuthError, LiquipediaError, NotFoundError, RateLimitError
-from liquipydia._response import ApiResponse
+# Local (explicit re-exports)
+from liquipydia._client import LiquipediaClient as LiquipediaClient
+from liquipydia._exceptions import ApiError as ApiError
+from liquipydia._exceptions import AuthError as AuthError
+from liquipydia._exceptions import LiquipediaError as LiquipediaError
+from liquipydia._exceptions import NotFoundError as NotFoundError
+from liquipydia._exceptions import RateLimitError as RateLimitError
+from liquipydia._response import ApiResponse as ApiResponse
 
 __version__ = "0.0.2"
 __author__ = "Dylan Monfret"

--- a/liquipydia/_client.py
+++ b/liquipydia/_client.py
@@ -1,0 +1,221 @@
+"""Core HTTP client for the Liquipedia API (LPDB v3)."""
+
+# Standard library
+from collections.abc import Iterator
+import os
+import time
+from types import TracebackType
+from typing import Any, Final, Self
+
+# Third-party
+import httpx
+
+# Local
+from liquipydia._exceptions import ApiError, AuthError, LiquipediaError, NotFoundError, RateLimitError
+from liquipydia._response import ApiResponse
+
+# === Constants ===
+
+_VERSION: Final[str] = "0.0.2"
+_BASE_URL: Final[str] = "https://api.liquipedia.net/api/v3/"
+_ENV_API_KEY: Final[str] = "LIQUIPEDIA_API_KEY"
+_MAX_BACKOFF: Final[float] = 60.0
+
+
+# === Client ===
+
+
+class LiquipediaClient:
+    """Synchronous client for the Liquipedia API v3.
+
+    Args:
+        app_name: Application name used in the User-Agent header.
+        api_key: API key for authentication. Falls back to the LIQUIPEDIA_API_KEY environment variable.
+        timeout: Request timeout in seconds.
+        max_retries: Maximum number of retries on HTTP 429 responses.
+        retry_backoff_factor: Base factor for exponential backoff on retries.
+
+    Examples:
+        >>> with LiquipediaClient("my-app", api_key="secret") as client:
+        ...     response = client._get("player", {"wiki": "dota2"})
+    """
+
+    def __init__(
+        self,
+        app_name: str,
+        api_key: str | None = None,
+        *,
+        timeout: float = 30.0,
+        max_retries: int = 3,
+        retry_backoff_factor: float = 1.0,
+    ) -> None:
+        self._max_retries = max_retries
+        self._retry_backoff_factor = retry_backoff_factor
+
+        resolved_key = api_key or os.environ.get(_ENV_API_KEY)
+
+        headers: dict[str, str] = {
+            "User-Agent": f"{app_name} (via liquipydia/{_VERSION})",
+            "Accept-Encoding": "gzip",
+        }
+
+        if resolved_key:
+            headers["Authorization"] = f"Apikey {resolved_key}"
+
+        self._http = httpx.Client(base_url=_BASE_URL, headers=headers, timeout=timeout)
+
+    # --- Context manager ---
+
+    def __enter__(self) -> Self:
+        """Enter the client context manager."""
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        """Exit the client context manager and close the HTTP session."""
+        self.close()
+
+    def close(self) -> None:
+        """Close the underlying HTTP session."""
+        self._http.close()
+
+    # --- Request handling ---
+
+    def _get(self, endpoint: str, params: dict[str, Any]) -> ApiResponse:
+        """Send a GET request to the API and return the parsed response.
+
+        Args:
+            endpoint: API path segment (e.g. ``"player"``).
+            params: Query parameters to include in the request.
+
+        Returns:
+            Parsed API response.
+
+        Raises:
+            AuthError: If the API key is invalid or missing (HTTP 403).
+            NotFoundError: If the requested data does not exist (HTTP 404).
+            RateLimitError: If retries are exhausted after HTTP 429 responses.
+            ApiError: If the API returns an error in the response body.
+            LiquipediaError: For other unexpected HTTP errors.
+        """
+        last_retry_after: int | None = None
+
+        for attempt in range(self._max_retries + 1):
+            response = self._http.get(endpoint, params=params)
+
+            if response.status_code != 429:
+                return self._parse_response(response)
+
+            retry_after = self._get_retry_after(response)
+            last_retry_after = retry_after
+            backoff = min(self._retry_backoff_factor * (2**attempt), _MAX_BACKOFF)
+            sleep_duration: float = retry_after if retry_after > 0 else backoff
+
+            if attempt < self._max_retries:
+                time.sleep(sleep_duration)
+
+        raise RateLimitError("Rate limit exceeded after retries", retry_after=last_retry_after)
+
+    @staticmethod
+    def _parse_response(response: httpx.Response) -> ApiResponse:
+        """Parse an HTTP response into an ApiResponse.
+
+        Args:
+            response: The raw httpx response.
+
+        Returns:
+            Parsed API response.
+
+        Raises:
+            AuthError: On HTTP 403.
+            NotFoundError: On HTTP 404.
+            LiquipediaError: On other HTTP errors.
+            ApiError: When the response body contains an error array.
+        """
+        if response.status_code == 403:
+            raise AuthError("Invalid or missing API key")
+
+        if response.status_code == 404:
+            raise NotFoundError("Requested data does not exist")
+
+        if response.status_code >= 400:
+            raise LiquipediaError(f"HTTP {response.status_code}: {response.text}")
+
+        body: dict[str, Any] = response.json()
+
+        errors: list[str] = body.get("error", [])
+        if errors:
+            raise ApiError("; ".join(errors))
+
+        return ApiResponse(
+            result=body.get("result", []),
+            warnings=body.get("warning", []),
+        )
+
+    # --- Pagination ---
+
+    def paginate(
+        self,
+        endpoint: str,
+        params: dict[str, Any],
+        *,
+        page_size: int = 20,
+        max_results: int | None = None,
+    ) -> Iterator[dict[str, Any]]:
+        """Iterate through paginated API results.
+
+        Yields individual record dicts, automatically requesting successive pages.
+        Stops when a page returns fewer records than ``page_size`` or when
+        ``max_results`` records have been yielded.
+
+        Args:
+            endpoint: API path segment (e.g. ``"player"``).
+            params: Base query parameters (``limit`` and ``offset`` are managed internally).
+            page_size: Number of records per page (max 1000).
+            max_results: Stop after yielding this many records. None for unlimited.
+
+        Yields:
+            Individual record dicts from the API.
+        """
+        offset = 0
+        yielded = 0
+
+        while True:
+            page_params = params | {"limit": page_size, "offset": offset}
+            response = self._get(endpoint, page_params)
+            records = response.result
+
+            for record in records:
+                yield record
+                yielded += 1
+
+                if max_results is not None and yielded >= max_results:
+                    return
+
+            if len(records) < page_size:
+                return
+
+            offset += page_size
+
+    # --- Helpers ---
+
+    @staticmethod
+    def _get_retry_after(response: httpx.Response) -> int:
+        """Extract the Retry-After header value from a response.
+
+        Args:
+            response: The HTTP response to extract the header from.
+
+        Returns:
+            Retry-After value in seconds, or 0 if the header is absent or invalid.
+        """
+        raw = response.headers.get("Retry-After", "")
+
+        try:
+            return int(raw)
+        except ValueError:
+            return 0

--- a/liquipydia/_exceptions.py
+++ b/liquipydia/_exceptions.py
@@ -1,0 +1,33 @@
+"""Custom exception types for the liquipydia library."""
+
+
+class LiquipediaError(Exception):
+    """Base exception for all liquipydia errors."""
+
+    def __init__(self, message: str) -> None:
+        self.message = message
+        super().__init__(message)
+
+
+class AuthError(LiquipediaError):
+    """Raised when the API key is invalid or missing (HTTP 403)."""
+
+
+class NotFoundError(LiquipediaError):
+    """Raised when the requested data does not exist (HTTP 404)."""
+
+
+class RateLimitError(LiquipediaError):
+    """Raised when the API rate limit is exceeded (HTTP 429).
+
+    Attributes:
+        retry_after: Suggested wait time in seconds before retrying, or None if unknown.
+    """
+
+    def __init__(self, message: str, *, retry_after: int | None = None) -> None:
+        self.retry_after = retry_after
+        super().__init__(message)
+
+
+class ApiError(LiquipediaError):
+    """Raised when the API returns an error in the response body."""

--- a/liquipydia/_response.py
+++ b/liquipydia/_response.py
@@ -1,0 +1,18 @@
+"""Response wrapper for parsed API envelopes."""
+
+# Standard library
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ApiResponse:
+    """Parsed response from the Liquipedia API.
+
+    Attributes:
+        result: List of record dicts returned by the API.
+        warnings: List of warning strings (empty if none).
+    """
+
+    result: list[dict[str, Any]]
+    warnings: list[str]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ select = [
 ]
 ignore = [
     "D104", # missing docstring in public package
+    "RUF022", # __all__ sorting (we use comment-grouped entries)
 ]
 
 [tool.ruff.lint.per-file-ignores]


### PR DESCRIPTION
## Summary

Implement the v0.0.2 milestone — the foundational `LiquipediaClient` that handles transport, authentication, rate
limiting, and response parsing for the Liquipedia API v3. This is the base layer that resource classes (v0.0.3) and
Pydantic models (v0.0.4) will build on.

## Changes

### Core client (`liquipydia/_client.py`)

* `LiquipediaClient` class wrapping `httpx.Client` with context manager and explicit `close()` support
* API key resolution from constructor parameter or `LIQUIPEDIA_API_KEY` environment variable
* Automatic headers: `User-Agent` (with app name and library version), `Accept-Encoding: gzip`, `Authorization`
* `_get(endpoint, params)` method with truncated exponential backoff on HTTP 429 (respects `Retry-After` header)
* `paginate(endpoint, params)` public generator for automatic offset/limit iteration across pages
* `_parse_response()` maps HTTP status codes to typed exceptions and extracts the response envelope

### Exceptions (`liquipydia/_exceptions.py`)

* `LiquipediaError` base exception with `message` attribute
* `AuthError` (403), `NotFoundError` (404), `RateLimitError` (429, carries `retry_after`), `ApiError` (body-level errors)

### Response wrapper (`liquipydia/_response.py`)

* `ApiResponse` frozen dataclass with `result: list[dict]` and `warnings: list[str]`

### Package updates

* Bump `__version__` to `0.0.2`, re-export `LiquipediaClient`, `ApiResponse`, and all exceptions from `__init__.py`
* Disable `RUF022` ruff rule to preserve comment-grouped `__all__` entries

### Tests

* `test_client.py` — constructor headers, context manager, response parsing, HTTP error mapping, 429 retry behavior,
  pagination (single page, multi-page, max_results, param immutability)
* `test_exceptions.py` — inheritance hierarchy, `RateLimitError.retry_after` attribute
* `test_response.py` — field storage, empty defaults, immutability
* `test_init.py` — version assertion updated to 0.0.2

### Documentation

* README: updated project structure tree, added working quick start example with `_get` and `paginate`
* Roadmap: checked off all v0.0.2 items, refined descriptions to match implementation

## Validation steps before merge

- [x] Lint & Test CI OK (no regression)
- [x] DeepSource Health-Check OK (no regression)
- [x] Human review completed (post-changes made by DeepSource or automated tools)
