### PR TITLE
feat(resources): resource layer with 16 LPDB v3 data types

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,5 +15,5 @@
 ## Validation steps before merge
 
 - [ ] Lint & Test CI OK (no regression)
-- [ ] DeepSource Health-Check OK (no regression)
+- [ ] DeepSource health check OK (no regression)
 - [ ] Human review completed (post-changes made by DeepSource or automated tools)

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Built with [`httpx`](https://www.python-httpx.org/) and [`pydantic`](https://doc
 liquipydia/
 ├── __init__.py       # Package exports, version
 ├── _client.py        # Core HTTP client (LiquipediaClient)
+├── _resources.py     # Resource classes (one per LPDB data type)
 ├── _exceptions.py    # Exception hierarchy
 ├── _response.py      # API response wrapper
 └── py.typed          # PEP 561 type marker
@@ -56,15 +57,47 @@ pip install git+https://github.com/Dyl-M/liquipydia.git
 from liquipydia import LiquipediaClient
 
 with LiquipediaClient("my-app", api_key="your-api-key") as client:
-    # Low-level request (resource helpers coming in v0.0.3)
-    response = client._get("player", {"wiki": "dota2", "limit": 5})
+    # Query players from a specific wiki
+    response = client.players.list("dota2", conditions="[[name::Miracle-]]")
     for player in response.result:
         print(player)
 
-    # Automatic pagination
-    for match in client.paginate("match", {"wiki": "counterstrike"}, page_size=100, max_results=500):
+    # Automatic pagination across multiple pages
+    for match in client.matches.paginate("counterstrike", page_size=100, max_results=500):
         print(match)
+
+    # Keyword filters — no need to write raw LPDB conditions
+    response = client.players.list("rocketleague", pagename="Zen")
+
+    # Match-specific parameters (stream data)
+    response = client.matches.list("rocketleague", rawstreams=True, streamurls=True)
+
+    # Team template lookup
+    response = client.team_templates.get("dota2", "teamliquid")
 ```
+
+### Available Resources
+
+All 16 LPDB v3 data types are accessible as client attributes:
+
+| Attribute                     | Endpoint             | Notes                             |
+|-------------------------------|----------------------|-----------------------------------|
+| `client.broadcasters`         | `/broadcasters`      |                                   |
+| `client.companies`            | `/company`           |                                   |
+| `client.datapoints`           | `/datapoint`         |                                   |
+| `client.external_media_links` | `/externalmedialink` |                                   |
+| `client.matches`              | `/match`             | Extra: `rawstreams`, `streamurls` |
+| `client.placements`           | `/placement`         |                                   |
+| `client.players`              | `/player`            |                                   |
+| `client.series`               | `/series`            |                                   |
+| `client.squad_players`        | `/squadplayer`       |                                   |
+| `client.standings_entries`    | `/standingsentry`    |                                   |
+| `client.standings_tables`     | `/standingstable`    |                                   |
+| `client.teams`                | `/team`              |                                   |
+| `client.tournaments`          | `/tournament`        |                                   |
+| `client.transfers`            | `/transfer`          |                                   |
+| `client.team_templates`       | `/teamtemplate`      | Uses `get()` instead of `list()`  |
+| `client.team_template_list`   | `/teamtemplatelist`  | Different params (`pagination`)   |
 
 > The API key can also be set via the `LIQUIPEDIA_API_KEY` environment variable.
 

--- a/_docs/ROADMAP.md
+++ b/_docs/ROADMAP.md
@@ -35,31 +35,57 @@ The foundation everything else depends on. Handles transport, auth, compliance w
 One resource class per LPDB data type, attached to the client as attributes. Each resource mirrors a single API
 endpoint.
 
-- [ ] Base `Resource` class with shared logic (`list`, `get_by_id` if applicable)
-- [ ] `client.broadcasters` — `/v3/broadcasters`
-- [ ] `client.companies` — `/v3/company`
-- [ ] `client.datapoints` — `/v3/datapoint`
-- [ ] `client.external_media_links` — `/v3/externalmedialink`
-- [ ] `client.matches` — `/v3/match`
-- [ ] `client.placements` — `/v3/placement`
-- [ ] `client.players` — `/v3/player`
-- [ ] `client.series` — `/v3/series`
-- [ ] `client.squad_players` — `/v3/squadplayer`
-- [ ] `client.standings_entries` — `/v3/standingsentry`
-- [ ] `client.standings_tables` — `/v3/standingstable`
-- [ ] `client.teams` — `/v3/team`
-- [ ] `client.tournaments` — `/v3/tournament`
-- [ ] `client.transfers` — `/v3/transfer`
-- [ ] `client.team_templates` — `/v3/teamtemplate`
-- [ ] `client.team_template_list` — `/v3/teamtemplatelist`
+- [x] Base `Resource` class with shared logic (`list`, `paginate`)
+- [x] Named subclass per standard endpoint (13 subclasses inheriting from `Resource`)
+- [x] `MatchResource` subclass with extra `rawstreams` / `streamurls` parameters
+- [x] `TeamTemplateResource` (standalone, uses `get()` — different API signature)
+- [x] `TeamTemplateListResource` (standalone, uses `pagination` param)
+- [x] Keyword filters: `**filters` kwargs on `list()` / `paginate()` auto-converted to LPDB conditions
+  (e.g. `name="Zen"` becomes `[[name::Zen]]`, combinable with explicit `conditions`)
+- [x] `client.broadcasters` — `/v3/broadcasters`
+- [x] `client.companies` — `/v3/company`
+- [x] `client.datapoints` — `/v3/datapoint`
+- [x] `client.external_media_links` — `/v3/externalmedialink`
+- [x] `client.matches` — `/v3/match`
+- [x] `client.placements` — `/v3/placement`
+- [x] `client.players` — `/v3/player`
+- [x] `client.series` — `/v3/series`
+- [x] `client.squad_players` — `/v3/squadplayer`
+- [x] `client.standings_entries` — `/v3/standingsentry`
+- [x] `client.standings_tables` — `/v3/standingstable`
+- [x] `client.teams` — `/v3/team`
+- [x] `client.tournaments` — `/v3/tournament`
+- [x] `client.transfers` — `/v3/transfer`
+- [x] `client.team_templates` — `/v3/teamtemplate`
+- [x] `client.team_template_list` — `/v3/teamtemplatelist`
 
-Each resource exposes at minimum:
+Each resource exposes:
 
 ```python
-def list(self, wiki: str, *, conditions: str | None, limit: int = 50, offset: int = 0, order: str | None) -> list[Model]
+def list(
+        self, wiki: str, *,
+        conditions: str | None, query: str | None,
+        limit: int = 50, offset: int = 0,
+        order: str | None, groupby: str | None,
+        rawstreams: bool = False, streamurls: bool = False,
+        **filters: str,
+) -> ApiResponse
+
+
+def paginate(
+        self, wiki: str, *,
+        conditions: str | None, query: str | None,
+        order: str | None, groupby: str | None,
+        rawstreams: bool = False, streamurls: bool = False,
+        page_size: int = 50, max_results: int | None,
+        **filters: str,
+) -> Iterator[dict]
 ```
 
-Query parameter mapping follows the LPDB v3 API (wiki, conditions, limit, offset, order, etc.).
+- `rawstreams` / `streamurls` are only meaningful on the `/match` endpoint (ignored by others).
+- `**filters` are keyword arguments auto-converted to LPDB conditions (e.g. `pagename="Zen"` → `[[pagename::Zen]]`).
+  Supports `>`, `<`, `!` operator prefixes.
+- Query parameter mapping follows the LPDB v3 API (wiki, conditions, limit, offset, order, groupby, etc.).
 
 ## v0.0.4 — Pydantic models
 

--- a/_tests/test_client.py
+++ b/_tests/test_client.py
@@ -293,7 +293,8 @@ class TestPagination:
 
         assert params == {"wiki": "dota2"}
 
-    def test_paginate_invalid_page_size(self) -> None:
+    @staticmethod
+    def test_paginate_invalid_page_size() -> None:
         """Verify paginate() raises ValueError when page_size < 1."""
         with _make_client() as client, pytest.raises(ValueError, match="page_size must be >= 1"):
             list(client.paginate("player", {"wiki": "dota2"}, page_size=0))

--- a/_tests/test_client.py
+++ b/_tests/test_client.py
@@ -292,3 +292,8 @@ class TestPagination:
             list(client.paginate("player", params, page_size=10))
 
         assert params == {"wiki": "dota2"}
+
+    def test_paginate_invalid_page_size(self) -> None:
+        """Verify paginate() raises ValueError when page_size < 1."""
+        with _make_client() as client, pytest.raises(ValueError, match="page_size must be >= 1"):
+            list(client.paginate("player", {"wiki": "dota2"}, page_size=0))

--- a/_tests/test_client.py
+++ b/_tests/test_client.py
@@ -38,7 +38,7 @@ class TestConstructor:
         respx.get(f"{BASE_URL}player").mock(return_value=httpx.Response(200, json={"result": []}))
 
         with _make_client(app_name="my-app") as client:
-            client._get("player", {"wiki": "dota2"})
+            client.get("player", {"wiki": "dota2"})
 
         request = respx.calls.last.request
         assert request.headers["User-Agent"] == f"my-app (via liquipydia/{__version__})"
@@ -49,7 +49,7 @@ class TestConstructor:
         respx.get(f"{BASE_URL}player").mock(return_value=httpx.Response(200, json={"result": []}))
 
         with _make_client(api_key="secret-key") as client:
-            client._get("player", {"wiki": "dota2"})
+            client.get("player", {"wiki": "dota2"})
 
         request = respx.calls.last.request
         assert request.headers["Authorization"] == "Apikey secret-key"
@@ -61,7 +61,7 @@ class TestConstructor:
         respx.get(f"{BASE_URL}player").mock(return_value=httpx.Response(200, json={"result": []}))
 
         with LiquipediaClient("test-app", api_key=None) as client:
-            client._get("player", {"wiki": "dota2"})
+            client.get("player", {"wiki": "dota2"})
 
         request = respx.calls.last.request
         assert "Authorization" not in request.headers
@@ -72,7 +72,7 @@ class TestConstructor:
         respx.get(f"{BASE_URL}player").mock(return_value=httpx.Response(200, json={"result": []}))
 
         with _make_client() as client:
-            client._get("player", {"wiki": "dota2"})
+            client.get("player", {"wiki": "dota2"})
 
         request = respx.calls.last.request
         assert "gzip" in request.headers["Accept-Encoding"]
@@ -123,7 +123,7 @@ class TestParseResponse:
         respx.get(f"{BASE_URL}player").mock(return_value=httpx.Response(200, json={"result": [{"name": "Miracle-"}]}))
 
         with _make_client() as client:
-            response = client._get("player", {"wiki": "dota2"})
+            response = client.get("player", {"wiki": "dota2"})
 
         assert response.result == [{"name": "Miracle-"}]
 
@@ -138,7 +138,7 @@ class TestParseResponse:
         )
 
         with _make_client() as client:
-            response = client._get("player", {"wiki": "dota2"})
+            response = client.get("player", {"wiki": "dota2"})
 
         assert response.warnings == ["deprecated field"]
 
@@ -150,7 +150,7 @@ class TestParseResponse:
         )
 
         with _make_client() as client, pytest.raises(ApiError, match="unknown wiki"):
-            client._get("player", {"wiki": "badwiki"})
+            client.get("player", {"wiki": "badwiki"})
 
 
 # === HTTP Error Handling ===
@@ -165,7 +165,7 @@ class TestHttpErrors:
         respx.get(f"{BASE_URL}player").mock(return_value=httpx.Response(403))
 
         with _make_client() as client, pytest.raises(AuthError):
-            client._get("player", {"wiki": "dota2"})
+            client.get("player", {"wiki": "dota2"})
 
     @respx.mock
     def test_404_raises_not_found_error(self) -> None:
@@ -173,7 +173,7 @@ class TestHttpErrors:
         respx.get(f"{BASE_URL}player").mock(return_value=httpx.Response(404))
 
         with _make_client() as client, pytest.raises(NotFoundError):
-            client._get("player", {"wiki": "dota2"})
+            client.get("player", {"wiki": "dota2"})
 
     @respx.mock
     def test_500_raises_liquipedia_error(self) -> None:
@@ -181,7 +181,7 @@ class TestHttpErrors:
         respx.get(f"{BASE_URL}player").mock(return_value=httpx.Response(500, text="Internal Server Error"))
 
         with _make_client() as client, pytest.raises(LiquipediaError, match="HTTP 500"):
-            client._get("player", {"wiki": "dota2"})
+            client.get("player", {"wiki": "dota2"})
 
 
 # === Rate Limiting ===
@@ -200,7 +200,7 @@ class TestRateLimiting:
         ]
 
         with _make_client(max_retries=3, retry_backoff_factor=0.0) as client:
-            response = client._get("player", {"wiki": "dota2"})
+            response = client.get("player", {"wiki": "dota2"})
 
         assert response.result == [{"id": 1}]
         assert route.call_count == 2
@@ -211,7 +211,7 @@ class TestRateLimiting:
         respx.get(f"{BASE_URL}player").mock(return_value=httpx.Response(429, headers={"Retry-After": "0"}))
 
         with _make_client(max_retries=2, retry_backoff_factor=0.0) as client, pytest.raises(RateLimitError):
-            client._get("player", {"wiki": "dota2"})
+            client.get("player", {"wiki": "dota2"})
 
     @respx.mock
     def test_429_uses_retry_after_header(self) -> None:
@@ -219,7 +219,7 @@ class TestRateLimiting:
         respx.get(f"{BASE_URL}player").mock(return_value=httpx.Response(429, headers={"Retry-After": "42"}))
 
         with _make_client(max_retries=0) as client, pytest.raises(RateLimitError) as exc_info:
-            client._get("player", {"wiki": "dota2"})
+            client.get("player", {"wiki": "dota2"})
 
         assert exc_info.value.retry_after == 42
 
@@ -233,7 +233,7 @@ class TestRateLimiting:
         ]
 
         with _make_client(max_retries=3, retry_backoff_factor=0.0) as client:
-            response = client._get("player", {"wiki": "dota2"})
+            response = client.get("player", {"wiki": "dota2"})
 
         assert response.result == [{"id": 1}]
 

--- a/_tests/test_init.py
+++ b/_tests/test_init.py
@@ -10,7 +10,7 @@ def test_version_is_string() -> None:
 
 def test_version_value() -> None:
     """Verify that __version__ matches the expected value."""
-    assert __version__ == "0.0.2"
+    assert __version__ == "0.0.3"
 
 
 def test_author() -> None:

--- a/_tests/test_resources.py
+++ b/_tests/test_resources.py
@@ -1,0 +1,453 @@
+"""Tests for the liquipydia resource layer."""
+
+# Standard library
+from urllib.parse import parse_qs
+
+# Third-party
+import httpx
+import respx
+
+# Local
+from liquipydia import (
+    ApiResponse,
+    BroadcastersResource,
+    CompaniesResource,
+    DatapointsResource,
+    ExternalMediaLinksResource,
+    LiquipediaClient,
+    MatchResource,
+    PlacementsResource,
+    PlayersResource,
+    Resource,
+    SeriesResource,
+    SquadPlayersResource,
+    StandingsEntriesResource,
+    StandingsTablesResource,
+    TeamsResource,
+    TeamTemplateListResource,
+    TeamTemplateResource,
+    TournamentsResource,
+    TransfersResource,
+)
+
+BASE_URL = "https://api.liquipedia.net/api/v3/"
+
+
+# === Helpers ===
+
+
+def _make_client(**kwargs: object) -> LiquipediaClient:
+    """Create a client with defaults suitable for testing."""
+    defaults: dict[str, object] = {"app_name": "test-app", "api_key": "test-key", "timeout": 5.0}
+    defaults.update(kwargs)
+    return LiquipediaClient(**defaults)  # type: ignore[arg-type]
+
+
+def _get_query_params(request: httpx.Request) -> dict[str, str]:
+    """Extract query parameters from a request as a flat dict."""
+    parsed = parse_qs(str(request.url.params))
+    return {k: v[0] for k, v in parsed.items()}
+
+
+# === Base Resource ===
+
+
+class TestResource:
+    """Tests for the base Resource class using the players' endpoint."""
+
+    @respx.mock
+    def test_list_sends_correct_endpoint(self) -> None:
+        """Verify list() sends a GET to the correct endpoint URL."""
+        route = respx.get(f"{BASE_URL}player").mock(return_value=httpx.Response(200, json={"result": []}))
+
+        with _make_client() as client:
+            client.players.list("dota2")
+
+        assert route.called
+
+    @respx.mock
+    def test_list_passes_wiki_param(self) -> None:
+        """Verify wiki parameter is included in the request."""
+        respx.get(f"{BASE_URL}player").mock(return_value=httpx.Response(200, json={"result": []}))
+
+        with _make_client() as client:
+            client.players.list("dota2")
+
+        params = _get_query_params(respx.calls.last.request)
+        assert params["wiki"] == "dota2"
+
+    @respx.mock
+    def test_list_passes_conditions(self) -> None:
+        """Verify conditions parameter is forwarded."""
+        respx.get(f"{BASE_URL}player").mock(return_value=httpx.Response(200, json={"result": []}))
+
+        with _make_client() as client:
+            client.players.list("dota2", conditions="[[name::Miracle-]]")
+
+        params = _get_query_params(respx.calls.last.request)
+        assert params["conditions"] == "[[name::Miracle-]]"
+
+    @respx.mock
+    def test_list_excludes_none_params(self) -> None:
+        """Verify None-valued optional parameters are excluded from the request."""
+        respx.get(f"{BASE_URL}player").mock(return_value=httpx.Response(200, json={"result": []}))
+
+        with _make_client() as client:
+            client.players.list("dota2")
+
+        params = _get_query_params(respx.calls.last.request)
+        assert "conditions" not in params
+        assert "query" not in params
+        assert "order" not in params
+        assert "groupby" not in params
+
+    @respx.mock
+    def test_list_default_limit(self) -> None:
+        """Verify default limit is 50."""
+        respx.get(f"{BASE_URL}player").mock(return_value=httpx.Response(200, json={"result": []}))
+
+        with _make_client() as client:
+            client.players.list("dota2")
+
+        params = _get_query_params(respx.calls.last.request)
+        assert params["limit"] == "50"
+
+    @respx.mock
+    def test_list_returns_api_response(self) -> None:
+        """Verify list() returns an ApiResponse instance."""
+        respx.get(f"{BASE_URL}player").mock(return_value=httpx.Response(200, json={"result": [{"name": "Miracle-"}]}))
+
+        with _make_client() as client:
+            response = client.players.list("dota2")
+
+        assert isinstance(response, ApiResponse)
+        assert response.result == [{"name": "Miracle-"}]
+
+    @respx.mock
+    def test_list_passes_all_params(self) -> None:
+        """Verify all optional parameters are forwarded when provided."""
+        respx.get(f"{BASE_URL}player").mock(return_value=httpx.Response(200, json={"result": []}))
+
+        with _make_client() as client:
+            client.players.list(
+                "dota2",
+                conditions="[[name::Miracle-]]",
+                query="name,id",
+                limit=10,
+                offset=5,
+                order="name ASC",
+                groupby="nationality",
+            )
+
+        params = _get_query_params(respx.calls.last.request)
+        assert params["conditions"] == "[[name::Miracle-]]"
+        assert params["query"] == "name,id"
+        assert params["limit"] == "10"
+        assert params["offset"] == "5"
+        assert params["order"] == "name ASC"
+        assert params["groupby"] == "nationality"
+
+    @respx.mock
+    def test_paginate_yields_records(self) -> None:
+        """Verify paginate() yields individual records."""
+        route = respx.get(f"{BASE_URL}player")
+        route.side_effect = [
+            httpx.Response(200, json={"result": [{"id": 1}, {"id": 2}]}),
+            httpx.Response(200, json={"result": [{"id": 3}]}),
+        ]
+
+        with _make_client() as client:
+            records = list(client.players.paginate("dota2", page_size=2))
+
+        assert records == [{"id": 1}, {"id": 2}, {"id": 3}]
+        assert route.call_count == 2
+
+    @respx.mock
+    def test_paginate_excludes_none_params(self) -> None:
+        """Verify paginate() excludes None-valued optional parameters."""
+        respx.get(f"{BASE_URL}player").mock(return_value=httpx.Response(200, json={"result": []}))
+
+        with _make_client() as client:
+            list(client.players.paginate("dota2"))
+
+        params = _get_query_params(respx.calls.last.request)
+        assert "conditions" not in params
+        assert "order" not in params
+
+
+# === Keyword Filters ===
+
+
+class TestKeywordFilters:
+    """Tests for keyword filter conversion to LPDB conditions."""
+
+    @respx.mock
+    def test_list_keyword_filter(self) -> None:
+        """Verify a single keyword filter is converted to a condition."""
+        respx.get(f"{BASE_URL}player").mock(return_value=httpx.Response(200, json={"result": []}))
+
+        with _make_client() as client:
+            client.players.list("rocketleague", name="Zen")
+
+        params = _get_query_params(respx.calls.last.request)
+        assert params["conditions"] == "[[name::Zen]]"
+
+    @respx.mock
+    def test_list_multiple_filters(self) -> None:
+        """Verify multiple keyword filters are AND-joined."""
+        respx.get(f"{BASE_URL}player").mock(return_value=httpx.Response(200, json={"result": []}))
+
+        with _make_client() as client:
+            client.players.list("rocketleague", name="Zen", nationality="fr")
+
+        params = _get_query_params(respx.calls.last.request)
+        assert "[[name::Zen]]" in params["conditions"]
+        assert "[[nationality::fr]]" in params["conditions"]
+        assert " AND " in params["conditions"]
+
+    @respx.mock
+    def test_list_filters_with_conditions(self) -> None:
+        """Verify keyword filters are AND-joined with explicit conditions."""
+        respx.get(f"{BASE_URL}player").mock(return_value=httpx.Response(200, json={"result": []}))
+
+        with _make_client() as client:
+            client.players.list("rocketleague", conditions="[[team::Vitality]]", name="Zen")
+
+        params = _get_query_params(respx.calls.last.request)
+        assert "[[team::Vitality]]" in params["conditions"]
+        assert "[[name::Zen]]" in params["conditions"]
+        assert " AND " in params["conditions"]
+
+    @respx.mock
+    def test_list_filter_with_operator(self) -> None:
+        """Verify operator prefixes in filter values are preserved."""
+        respx.get(f"{BASE_URL}placement").mock(return_value=httpx.Response(200, json={"result": []}))
+
+        with _make_client() as client:
+            client.placements.list("dota2", prizemoney=">10000")
+
+        params = _get_query_params(respx.calls.last.request)
+        assert params["conditions"] == "[[prizemoney::>10000]]"
+
+    @respx.mock
+    def test_list_no_filters_no_conditions(self) -> None:
+        """Verify no conditions param is sent when neither filters nor conditions are provided."""
+        respx.get(f"{BASE_URL}player").mock(return_value=httpx.Response(200, json={"result": []}))
+
+        with _make_client() as client:
+            client.players.list("rocketleague")
+
+        params = _get_query_params(respx.calls.last.request)
+        assert "conditions" not in params
+
+    @respx.mock
+    def test_paginate_keyword_filter(self) -> None:
+        """Verify keyword filters work with paginate()."""
+        respx.get(f"{BASE_URL}player").mock(return_value=httpx.Response(200, json={"result": []}))
+
+        with _make_client() as client:
+            list(client.players.paginate("rocketleague", name="Zen"))
+
+        params = _get_query_params(respx.calls.last.request)
+        assert params["conditions"] == "[[name::Zen]]"
+
+    @respx.mock
+    def test_match_filters_with_streams(self) -> None:
+        """Verify keyword filters coexist with match-specific stream params."""
+        respx.get(f"{BASE_URL}match").mock(return_value=httpx.Response(200, json={"result": []}))
+
+        with _make_client() as client:
+            client.matches.list("rocketleague", rawstreams=True, winner="1")
+
+        params = _get_query_params(respx.calls.last.request)
+        assert params["conditions"] == "[[winner::1]]"
+        assert params["rawstreams"] == "true"
+
+
+# === Match Resource ===
+
+
+class TestMatchResource:
+    """Tests for the MatchResource with stream parameters."""
+
+    @respx.mock
+    def test_list_includes_rawstreams(self) -> None:
+        """Verify rawstreams=True sends 'true' in params."""
+        respx.get(f"{BASE_URL}match").mock(return_value=httpx.Response(200, json={"result": []}))
+
+        with _make_client() as client:
+            client.matches.list("dota2", rawstreams=True)
+
+        params = _get_query_params(respx.calls.last.request)
+        assert params["rawstreams"] == "true"
+
+    @respx.mock
+    def test_list_includes_streamurls(self) -> None:
+        """Verify streamurls=True sends 'true' in params."""
+        respx.get(f"{BASE_URL}match").mock(return_value=httpx.Response(200, json={"result": []}))
+
+        with _make_client() as client:
+            client.matches.list("dota2", streamurls=True)
+
+        params = _get_query_params(respx.calls.last.request)
+        assert params["streamurls"] == "true"
+
+    @respx.mock
+    def test_list_defaults_exclude_streams(self) -> None:
+        """Verify stream parameters are excluded when False (default)."""
+        respx.get(f"{BASE_URL}match").mock(return_value=httpx.Response(200, json={"result": []}))
+
+        with _make_client() as client:
+            client.matches.list("dota2")
+
+        params = _get_query_params(respx.calls.last.request)
+        assert "rawstreams" not in params
+        assert "streamurls" not in params
+
+    @respx.mock
+    def test_paginate_includes_stream_params(self) -> None:
+        """Verify paginate() forwards stream parameters."""
+        respx.get(f"{BASE_URL}match").mock(return_value=httpx.Response(200, json={"result": []}))
+
+        with _make_client() as client:
+            list(client.matches.paginate("dota2", rawstreams=True, streamurls=True))
+
+        params = _get_query_params(respx.calls.last.request)
+        assert params["rawstreams"] == "true"
+        assert params["streamurls"] == "true"
+
+
+# === Team Template Resource ===
+
+
+class TestTeamTemplateResource:
+    """Tests for the TeamTemplateResource."""
+
+    @respx.mock
+    def test_get_sends_correct_endpoint(self) -> None:
+        """Verify get() sends a GET to the teamtemplate endpoint."""
+        route = respx.get(f"{BASE_URL}teamtemplate").mock(return_value=httpx.Response(200, json={"result": []}))
+
+        with _make_client() as client:
+            client.team_templates.get("dota2", "teamliquid")
+
+        assert route.called
+
+    @respx.mock
+    def test_get_sends_wiki_and_template(self) -> None:
+        """Verify wiki and template parameters are sent."""
+        respx.get(f"{BASE_URL}teamtemplate").mock(return_value=httpx.Response(200, json={"result": []}))
+
+        with _make_client() as client:
+            client.team_templates.get("dota2", "teamliquid")
+
+        params = _get_query_params(respx.calls.last.request)
+        assert params["wiki"] == "dota2"
+        assert params["template"] == "teamliquid"
+
+    @respx.mock
+    def test_get_optional_date(self) -> None:
+        """Verify date parameter is forwarded when provided."""
+        respx.get(f"{BASE_URL}teamtemplate").mock(return_value=httpx.Response(200, json={"result": []}))
+
+        with _make_client() as client:
+            client.team_templates.get("dota2", "teamliquid", date="2009-06-05")
+
+        params = _get_query_params(respx.calls.last.request)
+        assert params["date"] == "2009-06-05"
+
+    @respx.mock
+    def test_get_excludes_date_when_none(self) -> None:
+        """Verify date parameter is excluded when not provided."""
+        respx.get(f"{BASE_URL}teamtemplate").mock(return_value=httpx.Response(200, json={"result": []}))
+
+        with _make_client() as client:
+            client.team_templates.get("dota2", "teamliquid")
+
+        params = _get_query_params(respx.calls.last.request)
+        assert "date" not in params
+
+
+# === Team Template List Resource ===
+
+
+class TestTeamTemplateListResource:
+    """Tests for the TeamTemplateListResource."""
+
+    @respx.mock
+    def test_list_sends_correct_endpoint(self) -> None:
+        """Verify list() sends a GET to the teamtemplatelist endpoint."""
+        route = respx.get(f"{BASE_URL}teamtemplatelist").mock(return_value=httpx.Response(200, json={"result": []}))
+
+        with _make_client() as client:
+            client.team_template_list.list("dota2")
+
+        assert route.called
+
+    @respx.mock
+    def test_list_with_pagination(self) -> None:
+        """Verify pagination parameter is forwarded."""
+        respx.get(f"{BASE_URL}teamtemplatelist").mock(return_value=httpx.Response(200, json={"result": []}))
+
+        with _make_client() as client:
+            client.team_template_list.list("dota2", pagination=2)
+
+        params = _get_query_params(respx.calls.last.request)
+        assert params["pagination"] == "2"
+
+    @respx.mock
+    def test_list_excludes_pagination_when_none(self) -> None:
+        """Verify pagination is excluded when not provided."""
+        respx.get(f"{BASE_URL}teamtemplatelist").mock(return_value=httpx.Response(200, json={"result": []}))
+
+        with _make_client() as client:
+            client.team_template_list.list("dota2")
+
+        params = _get_query_params(respx.calls.last.request)
+        assert "pagination" not in params
+
+
+# === Client Resource Attributes ===
+
+
+class TestClientResourceAttributes:
+    """Tests for resource attributes on LiquipediaClient."""
+
+    @staticmethod
+    def test_all_resources_attached() -> None:
+        """Verify all 16 resource attributes exist and have the correct type."""
+        with _make_client() as client:
+            assert isinstance(client.broadcasters, BroadcastersResource)
+            assert isinstance(client.companies, CompaniesResource)
+            assert isinstance(client.datapoints, DatapointsResource)
+            assert isinstance(client.external_media_links, ExternalMediaLinksResource)
+            assert isinstance(client.matches, MatchResource)
+            assert isinstance(client.placements, PlacementsResource)
+            assert isinstance(client.players, PlayersResource)
+            assert isinstance(client.series, SeriesResource)
+            assert isinstance(client.squad_players, SquadPlayersResource)
+            assert isinstance(client.standings_entries, StandingsEntriesResource)
+            assert isinstance(client.standings_tables, StandingsTablesResource)
+            assert isinstance(client.teams, TeamsResource)
+            assert isinstance(client.tournaments, TournamentsResource)
+            assert isinstance(client.transfers, TransfersResource)
+            assert isinstance(client.team_templates, TeamTemplateResource)
+            assert isinstance(client.team_template_list, TeamTemplateListResource)
+
+    @staticmethod
+    def test_resources_are_resource_subclasses() -> None:
+        """Verify standard resources inherit from Resource."""
+        with _make_client() as client:
+            assert isinstance(client.players, Resource)
+            assert isinstance(client.teams, Resource)
+            assert isinstance(client.matches, Resource)
+
+    @staticmethod
+    def test_resource_endpoints() -> None:
+        """Verify a few resources point to the correct endpoint strings."""
+        with _make_client() as client:
+            assert client.players._endpoint == "player"
+            assert client.teams._endpoint == "team"
+            assert client.broadcasters._endpoint == "broadcasters"
+            assert client.matches._endpoint == "match"
+            assert client.external_media_links._endpoint == "externalmedialink"

--- a/liquipydia/__init__.py
+++ b/liquipydia/__init__.py
@@ -9,9 +9,28 @@ from liquipydia._exceptions import (  # skipcq: PY-W2000
     NotFoundError,
     RateLimitError,
 )
+from liquipydia._resources import (  # skipcq: PY-W2000
+    BroadcastersResource,
+    CompaniesResource,
+    DatapointsResource,
+    ExternalMediaLinksResource,
+    MatchResource,
+    PlacementsResource,
+    PlayersResource,
+    Resource,
+    SeriesResource,
+    SquadPlayersResource,
+    StandingsEntriesResource,
+    StandingsTablesResource,
+    TeamsResource,
+    TeamTemplateListResource,
+    TeamTemplateResource,
+    TournamentsResource,
+    TransfersResource,
+)
 from liquipydia._response import ApiResponse  # skipcq: PY-W2000
 
-__version__ = "0.0.2"
+__version__ = "0.0.3"
 __author__ = "Dylan Monfret"
 
 __all__: list[str] = [
@@ -22,6 +41,24 @@ __all__: list[str] = [
     "LiquipediaClient",
     # Response
     "ApiResponse",
+    # Resources
+    "BroadcastersResource",
+    "CompaniesResource",
+    "DatapointsResource",
+    "ExternalMediaLinksResource",
+    "MatchResource",
+    "PlacementsResource",
+    "PlayersResource",
+    "Resource",
+    "SeriesResource",
+    "SquadPlayersResource",
+    "StandingsEntriesResource",
+    "StandingsTablesResource",
+    "TeamsResource",
+    "TeamTemplateListResource",
+    "TeamTemplateResource",
+    "TournamentsResource",
+    "TransfersResource",
     # Exceptions
     "ApiError",
     "AuthError",

--- a/liquipydia/_client.py
+++ b/liquipydia/_client.py
@@ -12,11 +12,29 @@ import httpx
 
 # Local
 from liquipydia._exceptions import ApiError, AuthError, LiquipediaError, NotFoundError, RateLimitError
+from liquipydia._resources import (
+    BroadcastersResource,
+    CompaniesResource,
+    DatapointsResource,
+    ExternalMediaLinksResource,
+    MatchResource,
+    PlacementsResource,
+    PlayersResource,
+    SeriesResource,
+    SquadPlayersResource,
+    StandingsEntriesResource,
+    StandingsTablesResource,
+    TeamsResource,
+    TeamTemplateListResource,
+    TeamTemplateResource,
+    TournamentsResource,
+    TransfersResource,
+)
 from liquipydia._response import ApiResponse
 
 # === Constants ===
 
-_VERSION: Final[str] = "0.0.2"
+_VERSION: Final[str] = "0.0.3"
 _BASE_URL: Final[str] = "https://api.liquipedia.net/api/v3/"
 _ENV_API_KEY: Final[str] = "LIQUIPEDIA_API_KEY"
 _MAX_BACKOFF: Final[float] = 60.0
@@ -37,8 +55,27 @@ class LiquipediaClient:
 
     Examples:
         >>> with LiquipediaClient("my-app", api_key="secret") as client:
-        ...     response = client._get("player", {"wiki": "dota2"})
+        ...     response = client.players.list("dota2")
     """
+
+    # --- Resource attributes ---
+
+    broadcasters: BroadcastersResource
+    companies: CompaniesResource
+    datapoints: DatapointsResource
+    external_media_links: ExternalMediaLinksResource
+    matches: MatchResource
+    placements: PlacementsResource
+    players: PlayersResource
+    series: SeriesResource
+    squad_players: SquadPlayersResource
+    standings_entries: StandingsEntriesResource
+    standings_tables: StandingsTablesResource
+    teams: TeamsResource
+    tournaments: TournamentsResource
+    transfers: TransfersResource
+    team_templates: TeamTemplateResource
+    team_template_list: TeamTemplateListResource
 
     def __init__(
         self,
@@ -64,6 +101,24 @@ class LiquipediaClient:
 
         self._http = httpx.Client(base_url=_BASE_URL, headers=headers, timeout=timeout)
 
+        # --- Resources ---
+        self.broadcasters = BroadcastersResource(self)
+        self.companies = CompaniesResource(self)
+        self.datapoints = DatapointsResource(self)
+        self.external_media_links = ExternalMediaLinksResource(self)
+        self.matches = MatchResource(self)
+        self.placements = PlacementsResource(self)
+        self.players = PlayersResource(self)
+        self.series = SeriesResource(self)
+        self.squad_players = SquadPlayersResource(self)
+        self.standings_entries = StandingsEntriesResource(self)
+        self.standings_tables = StandingsTablesResource(self)
+        self.teams = TeamsResource(self)
+        self.tournaments = TournamentsResource(self)
+        self.transfers = TransfersResource(self)
+        self.team_templates = TeamTemplateResource(self)
+        self.team_template_list = TeamTemplateListResource(self)
+
     # --- Context manager ---
 
     def __enter__(self) -> Self:
@@ -85,7 +140,7 @@ class LiquipediaClient:
 
     # --- Request handling ---
 
-    def _get(self, endpoint: str, params: dict[str, Any]) -> ApiResponse:
+    def get(self, endpoint: str, params: dict[str, Any]) -> ApiResponse:
         """Send a GET request to the API and return the parsed response.
 
         Args:
@@ -181,12 +236,15 @@ class LiquipediaClient:
         Yields:
             Individual record dicts from the API.
         """
+        if page_size < 1:
+            raise ValueError(f"page_size must be >= 1, got {page_size}")
+
         offset = 0
         yielded = 0
 
         while True:
             page_params = params | {"limit": page_size, "offset": offset}
-            response = self._get(endpoint, page_params)
+            response = self.get(endpoint, page_params)
             records = response.result
 
             for record in records:

--- a/liquipydia/_resources.py
+++ b/liquipydia/_resources.py
@@ -1,0 +1,331 @@
+"""Resource classes for LPDB v3 endpoints."""
+
+# Standard library
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    # Local
+    from liquipydia._client import LiquipediaClient
+    from liquipydia._response import ApiResponse
+
+
+# === Base Resource ===
+
+
+class Resource:
+    """Base resource wrapping a single LPDB v3 endpoint.
+
+    Provides ``list`` and ``paginate`` methods that delegate HTTP calls to the parent client.
+
+    Args:
+        client: The parent LiquipediaClient instance.
+        endpoint: API path segment (e.g. ``"player"``).
+    """
+
+    _endpoint: str
+
+    def __init__(self, client: LiquipediaClient) -> None:
+        self._client = client
+
+    def list(
+        self,
+        wiki: str,
+        *,
+        conditions: str | None = None,
+        query: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+        order: str | None = None,
+        groupby: str | None = None,
+        rawstreams: bool = False,
+        streamurls: bool = False,
+        **filters: str,
+    ) -> ApiResponse:
+        """Query this endpoint and return results.
+
+        Args:
+            wiki: Wiki(s) to query (pipe-separate for multi-wiki, e.g. ``"dota2|counterstrike"``).
+            conditions: Filter expression using LPDB condition syntax.
+            query: Comma-separated list of fields to return.
+            limit: Maximum number of results (1--1000).
+            offset: Number of results to skip.
+            order: SQL-style ordering (e.g. ``"id ASC"``).
+            groupby: SQL-style grouping (e.g. ``"id ASC"``).
+            rawstreams: Return raw stream data (``/match`` endpoint only).
+            streamurls: Return stream URLs (``/match`` endpoint only).
+            **filters: Keyword filters converted to conditions (e.g. ``name="Zen"`` becomes
+                ``[[name::Zen]]``). Prefix values with ``>``, ``<``, or ``!`` for operators.
+
+        Returns:
+            Parsed API response.
+        """
+        merged = self._build_conditions(conditions, filters)
+        params = self._build_params(
+            {
+                "wiki": wiki,
+                "conditions": merged,
+                "query": query,
+                "limit": limit,
+                "offset": offset,
+                "order": order,
+                "groupby": groupby,
+                "rawstreams": str(rawstreams).lower() if rawstreams else None,
+                "streamurls": str(streamurls).lower() if streamurls else None,
+            }
+        )
+        return self._client.get(self._endpoint, params)
+
+    def paginate(
+        self,
+        wiki: str,
+        *,
+        conditions: str | None = None,
+        query: str | None = None,
+        order: str | None = None,
+        groupby: str | None = None,
+        rawstreams: bool = False,
+        streamurls: bool = False,
+        page_size: int = 50,
+        max_results: int | None = None,
+        **filters: str,
+    ) -> Iterator[dict[str, Any]]:
+        """Iterate through paginated results from this endpoint.
+
+        Yields individual record dicts, automatically requesting successive pages.
+
+        Args:
+            wiki: Wiki(s) to query.
+            conditions: Filter expression using LPDB condition syntax.
+            query: Comma-separated list of fields to return.
+            order: SQL-style ordering.
+            groupby: SQL-style grouping.
+            rawstreams: Return raw stream data (``/match`` endpoint only).
+            streamurls: Return stream URLs (``/match`` endpoint only).
+            page_size: Number of records per page (max 1000).
+            max_results: Stop after yielding this many records. ``None`` for unlimited.
+            **filters: Keyword filters converted to conditions (e.g. ``name="Zen"`` becomes
+                ``[[name::Zen]]``). Prefix values with ``>``, ``<``, or ``!`` for operators.
+
+        Yields:
+            Individual record dicts from the API.
+        """
+        merged = self._build_conditions(conditions, filters)
+        params = self._build_params(
+            {
+                "wiki": wiki,
+                "conditions": merged,
+                "query": query,
+                "order": order,
+                "groupby": groupby,
+                "rawstreams": str(rawstreams).lower() if rawstreams else None,
+                "streamurls": str(streamurls).lower() if streamurls else None,
+            }
+        )
+        yield from self._client.paginate(
+            self._endpoint,
+            params,
+            page_size=page_size,
+            max_results=max_results,
+        )
+
+    @staticmethod
+    def _build_conditions(conditions: str | None, filters: dict[str, str]) -> str | None:
+        """Merge an explicit conditions string with keyword filters.
+
+        Each filter becomes ``[[key::value]]``. Filters are AND-joined with each other
+        and with the explicit ``conditions`` string if provided. Values prefixed with
+        ``>``, ``<``, or ``!`` preserve their LPDB operator.
+
+        Args:
+            conditions: Explicit LPDB condition string (can be ``None``).
+            filters: Keyword filters to convert (e.g. ``{"name": "Zen"}``).
+
+        Returns:
+            Merged condition string, or ``None`` if both inputs are empty.
+        """
+        parts: list[str] = []
+        if conditions:
+            parts.append(conditions)
+        for key, value in filters.items():
+            parts.append(f"[[{key}::{value}]]")
+        return " AND ".join(parts) if parts else None
+
+    @staticmethod
+    def _build_params(raw: dict[str, Any]) -> dict[str, Any]:
+        """Build a query parameter dict, excluding ``None`` values.
+
+        Args:
+            raw: Raw parameter mapping (may contain ``None`` values).
+
+        Returns:
+            Filtered parameter dict.
+        """
+        return {k: v for k, v in raw.items() if v is not None}
+
+
+# === Standard Resources ===
+
+
+class BroadcastersResource(Resource):
+    """Resource for the ``/broadcasters`` endpoint."""
+
+    _endpoint = "broadcasters"
+
+
+class CompaniesResource(Resource):
+    """Resource for the ``/company`` endpoint."""
+
+    _endpoint = "company"
+
+
+class DatapointsResource(Resource):
+    """Resource for the ``/datapoint`` endpoint."""
+
+    _endpoint = "datapoint"
+
+
+class ExternalMediaLinksResource(Resource):
+    """Resource for the ``/externalmedialink`` endpoint."""
+
+    _endpoint = "externalmedialink"
+
+
+class PlacementsResource(Resource):
+    """Resource for the ``/placement`` endpoint."""
+
+    _endpoint = "placement"
+
+
+class PlayersResource(Resource):
+    """Resource for the ``/player`` endpoint."""
+
+    _endpoint = "player"
+
+
+class SeriesResource(Resource):
+    """Resource for the ``/series`` endpoint."""
+
+    _endpoint = "series"
+
+
+class SquadPlayersResource(Resource):
+    """Resource for the ``/squadplayer`` endpoint."""
+
+    _endpoint = "squadplayer"
+
+
+class StandingsEntriesResource(Resource):
+    """Resource for the ``/standingsentry`` endpoint."""
+
+    _endpoint = "standingsentry"
+
+
+class StandingsTablesResource(Resource):
+    """Resource for the ``/standingstable`` endpoint."""
+
+    _endpoint = "standingstable"
+
+
+class TeamsResource(Resource):
+    """Resource for the ``/team`` endpoint."""
+
+    _endpoint = "team"
+
+
+class TournamentsResource(Resource):
+    """Resource for the ``/tournament`` endpoint."""
+
+    _endpoint = "tournament"
+
+
+class TransfersResource(Resource):
+    """Resource for the ``/transfer`` endpoint."""
+
+    _endpoint = "transfer"
+
+
+# === Specialized Resources ===
+
+
+class MatchResource(Resource):
+    """Resource for the ``/match`` endpoint.
+
+    Supports ``rawstreams`` and ``streamurls`` parameters via the base ``list()``
+    and ``paginate()`` methods.
+    """
+
+    _endpoint = "match"
+
+
+class TeamTemplateResource:
+    """Resource for the ``/teamtemplate`` endpoint (single template lookup).
+
+    This endpoint has a different parameter signature from standard resources
+    and does not support ``conditions``, ``limit``, ``offset``, or ``order``.
+
+    Args:
+        client: The parent LiquipediaClient instance.
+    """
+
+    def __init__(self, client: LiquipediaClient) -> None:
+        self._client = client
+
+    def get(
+        self,
+        wiki: str,
+        template: str,
+        *,
+        date: str | None = None,
+    ) -> ApiResponse:
+        """Get a single team template.
+
+        Args:
+            wiki: Single wiki identifier (no multi-wiki).
+            template: Template name of the team template (e.g. ``"teamliquid"``).
+            date: Date for historical logos (format: ``YYYY-MM-DD``).
+
+        Returns:
+            Parsed API response.
+        """
+        params: dict[str, Any] = {"wiki": wiki, "template": template}
+        if date is not None:
+            params["date"] = date
+        return self._client.get("teamtemplate", params)
+
+
+class TeamTemplateListResource:
+    """Resource for the ``/teamtemplatelist`` endpoint.
+
+    This endpoint has a different parameter signature from standard resources
+    and does not support ``conditions``, ``limit``, ``offset``, or ``order``.
+
+    Args:
+        client: The parent LiquipediaClient instance.
+    """
+
+    def __init__(self, client: LiquipediaClient) -> None:
+        self._client = client
+
+    def list(
+        self,
+        wiki: str,
+        *,
+        pagination: int | None = None,
+    ) -> ApiResponse:
+        """Get a list of team templates.
+
+        Args:
+            wiki: Single wiki identifier (no multi-wiki).
+            pagination: Page number.
+
+        Returns:
+            Parsed API response.
+        """
+        params: dict[str, Any] = {"wiki": wiki}
+        if pagination is not None:
+            params["pagination"] = pagination
+        return self._client.get("teamtemplatelist", params)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "liquipydia"
-version = "0.0.1"
+version = "0.0.3"
 description = "Python client library for the Liquipedia API (LPDB v3)."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

Implement the v0.0.3 milestone — one resource class per LPDB v3 data type, attached to `LiquipediaClient` as typed
attributes. This replaces raw `client.get(endpoint, params)` calls with a structured, discoverable API
(e.g. `client.players.list("dota2")`). Also introduces keyword filters for user-friendly querying without raw LPDB
condition syntax.

## Changes

### Resource layer (`liquipydia/_resources.py`)

* Base `Resource` class with `list()` and `paginate()` methods delegating to the parent client
* 13 standard subclasses (one per endpoint: `PlayersResource`, `TeamsResource`, `TournamentsResource`, etc.)
* `MatchResource` subclass supporting `rawstreams`/`streamurls` params (excluded from request when `False`)
* `TeamTemplateResource` — standalone class with `get(wiki, template)` (different API signature)
* `TeamTemplateListResource` — standalone class with `list(wiki, pagination)` (different API signature)
* `_build_conditions()` static method merging explicit `conditions` with `**filters` kwargs
* `_build_params()` static method excluding `None` values from query parameters

### Keyword filters

* `**filters: str` on `list()` and `paginate()` auto-converted to LPDB conditions
  (e.g. `name="Zen"` → `[[name::Zen]]`), AND-joined with explicit `conditions`
* Supports `>`, `<`, `!` operator prefixes in filter values (e.g. `prizemoney=">10000"`)

### Client updates (`liquipydia/_client.py`)

* Attach all 16 resources as typed attributes on `LiquipediaClient`
* Rename `_get()` → `get()` to allow cross-module access from resources
* Add `page_size` validation in `paginate()` (`ValueError` if `< 1`)
* Bump `_VERSION` to `0.0.3`

### Package updates

* Re-export `Resource` and all 16 subclasses from `__init__.py`, update `__all__`
* Bump `__version__` to `0.0.3` and `pyproject.toml` version to `0.0.3`

### Tests

* `test_resources.py` — base resource, keyword filters, match streams, team templates, client attributes
* `test_client.py` — updated `_get()` → `get()` calls, added `page_size` validation test
* `test_init.py` — version assertion updated to `0.0.3`

### Documentation

* README: added `_resources.py` to project structure, replaced low-level examples with resource-based Quick Start,
  added Available Resources table
* Roadmap: marked all v0.0.3 items complete, updated method signatures and keyword filters documentation
* PR template: minor casing fix

## Validation steps before merge

- [x] Lint & Test CI OK (no regression)
- [x] DeepSource health check OK (no regression)
- [x] Human review completed (post-changes made by DeepSource or automated tools)
