### PR TITLE
feat(models): typed Pydantic models for all 16 LPDB v3 data types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.4] - 2026-04-06
+
+### Added
+
+- Pydantic models for all 16 LPDB v3 data types in `_models.py`: `Broadcaster`, `Company`, `Datapoint`,
+  `ExternalMediaLink`, `Match`, `Placement`, `Player`, `Series`, `SquadPlayer`, `StandingsEntry`, `StandingsTable`,
+  `Team`, `TeamTemplate`, `TeamTemplateList`, `Tournament`, `Transfer`
+- Private base classes: `_LpdbModel` (common fields for standard endpoints) and `_TeamTemplateBase` (different field set
+  for team template endpoints)
+- Reusable type aliases via `Annotated` + `BeforeValidator`: `NullableDate`, `NullableDatetime`, `LpdbDict` for
+  automatic conversion of LPDB null sentinels and empty dict placeholders
+- Standalone model usage: `Model.model_validate(record)` on dicts from `ApiResponse.result`
+- Typed Models section in README with usage examples and LPDB quirk handling notes
+- Test suite for Pydantic models covering construction, date normalization, model-specific parsing, and exports
+
+### Changed
+
+- Bump version to 0.0.4
+- Re-export all 16 models from `__init__.py` and add to `__all__`
+- Update Quick Start examples in README to demonstrate model validation with typed field access
+- Update roadmap with completed v0.0.4 items and checked off existing test milestones
+- Refactor `dev` dependency group to include `test` group via `include-group` instead of duplicating packages
+
+### Fixed
+
+- Suppress false positive DeepSource warning on `Placement` model
+
 ## [0.0.3] - 2026-04-06
 
 ### Added
@@ -82,8 +109,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Downgrade `astral-sh/setup-uv` from v8 to v7 (v8 major tag does not exist)
 - Enforce docstrings in test suite (remove pydocstyle exemption for `_tests/`)
 
-[Unreleased]: https://github.com/Dyl-M/liquipydia/compare/v0.0.3...dev
+[Unreleased]: https://github.com/Dyl-M/liquipydia/compare/v0.0.4...dev
+
+[0.0.4]: https://github.com/Dyl-M/liquipydia/compare/v0.0.3...v0.0.4
 
 [0.0.3]: https://github.com/Dyl-M/liquipydia/compare/v0.0.2...v0.0.3
+
 [0.0.2]: https://github.com/Dyl-M/liquipydia/compare/v0.0.1...v0.0.2
+
 [0.0.1]: https://github.com/Dyl-M/liquipydia/releases/tag/v0.0.1

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Built with [`httpx`](https://www.python-httpx.org/) and [`pydantic`](https://doc
 liquipydia/
 ├── __init__.py       # Package exports, version
 ├── _client.py        # Core HTTP client (LiquipediaClient)
+├── _models.py        # Pydantic models (one per LPDB data type)
 ├── _resources.py     # Resource classes (one per LPDB data type)
 ├── _exceptions.py    # Exception hierarchy
 ├── _response.py      # API response wrapper
@@ -54,17 +55,19 @@ pip install git+https://github.com/Dyl-M/liquipydia.git
 ## Quick Start
 
 ```python
-from liquipydia import LiquipediaClient
+from liquipydia import LiquipediaClient, Player, Match
 
 with LiquipediaClient("my-app", api_key="your-api-key") as client:
     # Query players from a specific wiki
     response = client.players.list("dota2", conditions="[[name::Miracle-]]")
-    for player in response.result:
-        print(player)
+    for record in response.result:
+        player = Player.model_validate(record)
+        print(player.name, player.nationality, player.birthdate)
 
     # Automatic pagination across multiple pages
-    for match in client.matches.paginate("counterstrike", page_size=100, max_results=500):
-        print(match)
+    for record in client.matches.paginate("counterstrike", page_size=100, max_results=500):
+        match = Match.model_validate(record)
+        print(match.match2id, match.date, match.winner)
 
     # Keyword filters — no need to write raw LPDB conditions
     response = client.players.list("rocketleague", pagename="Zen")
@@ -100,6 +103,28 @@ All 16 LPDB v3 data types are accessible as client attributes:
 | `client.team_template_list`   | `/teamtemplatelist`  | Different params (`pagination`)   |
 
 > The API key can also be set via the `LIQUIPEDIA_API_KEY` environment variable.
+
+### Typed Models
+
+Each data type has a corresponding Pydantic model for typed access and IDE autocompletion:
+
+`Broadcaster`, `Company`, `Datapoint`, `ExternalMediaLink`, `Match`, `Placement`, `Player`, `Series`, `SquadPlayer`,
+`StandingsEntry`, `StandingsTable`, `Team`, `TeamTemplate`, `TeamTemplateList`, `Tournament`, `Transfer`
+
+```python
+from liquipydia import Player
+
+player = Player.model_validate(record)
+print(player.name)  # str | None — with autocompletion
+print(player.birthdate)  # date | None — null sentinels auto-converted
+print(player.links)  # dict | None — empty API lists auto-converted
+```
+
+Models handle LPDB quirks automatically:
+
+- Null date sentinels (`"0000-01-01"`, `""`) → `None`
+- Empty dict placeholders (`[]`) → `None`
+- Unknown/future API fields are preserved (`extra="allow"`)
 
 ## Development
 

--- a/_docs/ROADMAP.md
+++ b/_docs/ROADMAP.md
@@ -91,22 +91,28 @@ def paginate(
 
 Typed response models for IDE autocompletion and validation. One model per data type.
 
-- [ ] One model per data type: `Broadcaster`, `Company`, `Datapoint`, `ExternalMediaLink`, `Match`, `Placement`,
-  `Player`, `Series`, `SquadPlayer`, `StandingsEntry`, `StandingsTable`, `Team`, `Tournament`, `Transfer`,
-  `TeamTemplate`, `TeamTemplateList`
-- [ ] Field mapping from API snake_case JSON → Python attributes
-- [ ] Optional fields handled with `None` defaults
-- [ ] Date/datetime parsing where applicable
-- [ ] Decision: strict validation vs. permissive (`model_config = ConfigDict(extra="allow")`)
-
-> **Note:** This phase depends on the full API field documentation. Models can start with known/common fields and expand
-> later.
+- [x] 16 Pydantic models in `liquipydia/_models.py`: `Broadcaster`, `Company`, `Datapoint`, `ExternalMediaLink`,
+  `Match`, `Placement`, `Player`, `Series`, `SquadPlayer`, `StandingsEntry`, `StandingsTable`, `Team`, `Tournament`,
+  `Transfer`, `TeamTemplate`, `TeamTemplateList`
+- [x] Private base classes: `_LpdbModel` (common fields for standard endpoints) and `_TeamTemplateBase` (different
+  field set for team template endpoints)
+- [x] All fields `type | None = None` — fully optional, forward-compatible
+- [x] `ConfigDict(extra="allow", populate_by_name=True)` — unknown/future API fields preserved
+- [x] Reusable type aliases via `Annotated` + `BeforeValidator`:
+    - `NullableDate` — converts LPDB null sentinels (`"0000-01-01"`, `""`) to `None`
+    - `NullableDatetime` — same for datetime fields (`"0000-01-01 00:00:00"`)
+    - `LpdbDict` — converts empty API lists (`[]`) to `None` for dict-like fields
+- [x] Standalone usage: `Model.model_validate(record)` on dicts from `ApiResponse.result`
+- [x] Field schemas discovered via live API calls (API does not document per-endpoint schemas)
+- [x] All 16 models re-exported from `__init__.py` and listed in `__all__`
+- [x] Test suite in `_tests/test_models.py` covering construction, date normalization, model-specific parsing, and
+  exports
 
 ## v0.0.5 — Tests and documentation
 
-- [ ] Unit tests for client (request building, headers, error handling) using `respx` to mock `httpx`
-- [ ] Unit tests for each resource (parameter construction, response parsing)
-- [ ] Unit tests for Pydantic models (validation, edge cases)
+- [x] Unit tests for client (request building, headers, error handling) using `respx` to mock `httpx`
+- [x] Unit tests for each resource (parameter construction, response parsing)
+- [x] Unit tests for Pydantic models (validation, edge cases)
 - [ ] Integration test suite (opt-in, requires real API key, skipped in CI by default)
 - [ ] `mkdocs-material` documentation site
     - Getting started / quickstart

--- a/_tests/test_init.py
+++ b/_tests/test_init.py
@@ -10,7 +10,7 @@ def test_version_is_string() -> None:
 
 def test_version_value() -> None:
     """Verify that __version__ matches the expected value."""
-    assert __version__ == "0.0.3"
+    assert __version__ == "0.0.4"
 
 
 def test_author() -> None:

--- a/_tests/test_models.py
+++ b/_tests/test_models.py
@@ -1,0 +1,360 @@
+"""Tests for Pydantic models."""
+
+# Standard library
+import datetime as dt
+from typing import ClassVar
+
+# Third-party
+import pytest
+
+# Local
+import liquipydia
+from liquipydia import (
+    Broadcaster,
+    Company,
+    Datapoint,
+    ExternalMediaLink,
+    Match,
+    Placement,
+    Player,
+    Series,
+    SquadPlayer,
+    StandingsEntry,
+    StandingsTable,
+    Team,
+    TeamTemplate,
+    TeamTemplateList,
+    Tournament,
+    Transfer,
+)
+
+# noinspection PyProtectedMember
+from liquipydia._models import _LpdbModel, _TeamTemplateBase
+
+# All 16 public model classes.
+ALL_MODELS = [
+    Broadcaster,
+    Company,
+    Datapoint,
+    ExternalMediaLink,
+    Match,
+    Placement,
+    Player,
+    Series,
+    SquadPlayer,
+    StandingsEntry,
+    StandingsTable,
+    Team,
+    TeamTemplate,
+    TeamTemplateList,
+    Tournament,
+    Transfer,
+]
+
+
+# === Base Model ===
+
+
+class TestLpdbModel:
+    """Tests for the _LpdbModel base class."""
+
+    @staticmethod
+    def test_accepts_common_fields() -> None:
+        """Verify common fields are parsed correctly."""
+        model = _LpdbModel.model_validate({"pageid": 123, "pagename": "Foo", "namespace": 0, "wiki": "dota2"})
+        assert model.pageid == 123
+        assert model.pagename == "Foo"
+        assert model.namespace == 0
+        assert model.wiki == "dota2"
+
+    @staticmethod
+    def test_all_fields_optional() -> None:
+        """Verify the model can be constructed with no arguments."""
+        model = _LpdbModel.model_validate({})
+        assert model.pageid is None
+        assert model.pagename is None
+
+    @staticmethod
+    def test_allows_extra_fields() -> None:
+        """Verify unknown fields are preserved (extra='allow')."""
+        model = _LpdbModel.model_validate({"pageid": 1, "unknown_field": "hello"})
+        assert model.unknown_field == "hello"  # type: ignore[attr-defined]
+
+
+# === All Models: Construction ===
+
+
+class TestAllModelsConstruction:
+    """Tests that apply to every model class."""
+
+    @staticmethod
+    @pytest.mark.parametrize("model_cls", ALL_MODELS, ids=lambda m: m.__name__)
+    def test_empty_construction(model_cls: type) -> None:
+        """Verify each model can be constructed with no arguments."""
+        model = model_cls.model_validate({})
+        assert model is not None
+
+    @staticmethod
+    @pytest.mark.parametrize("model_cls", ALL_MODELS, ids=lambda m: m.__name__)
+    def test_allows_extra_fields(model_cls: type) -> None:
+        """Verify each model accepts unknown fields."""
+        model = model_cls.model_validate({"some_future_field": 42})
+        assert model.some_future_field == 42  # type: ignore[attr-defined]
+
+
+# === Empty List Coercion ===
+
+
+class TestEmptyListCoercion:
+    """Tests for empty list to None conversion on LpdbDict fields."""
+
+    @staticmethod
+    def test_empty_list_becomes_none() -> None:
+        """Verify an empty list is converted to None for dict-like fields."""
+        player = Player.model_validate({"links": []})
+        assert player.links is None
+
+    @staticmethod
+    def test_dict_value_preserved() -> None:
+        """Verify a real dict value is kept as-is."""
+        player = Player.model_validate({"links": {"twitter": "https://twitter.com/test"}})
+        assert player.links == {"twitter": "https://twitter.com/test"}
+
+
+# === Date Normalization ===
+
+
+class TestDateNormalization:
+    """Tests for null date sentinel conversion."""
+
+    @staticmethod
+    def test_null_date_becomes_none() -> None:
+        """Verify '0000-01-01' is converted to None for date fields."""
+        player = Player.model_validate({"birthdate": "0000-01-01"})
+        assert player.birthdate is None
+
+    @staticmethod
+    def test_null_datetime_becomes_none() -> None:
+        """Verify '0000-01-01 00:00:00' is converted to None for datetime fields."""
+        company = Company.model_validate({"foundeddate": "0000-01-01 00:00:00"})
+        assert company.foundeddate is None
+
+    @staticmethod
+    def test_empty_string_becomes_none() -> None:
+        """Verify empty string is converted to None for date fields."""
+        player = Player.model_validate({"birthdate": ""})
+        assert player.birthdate is None
+
+    @staticmethod
+    def test_valid_date_parsed() -> None:
+        """Verify a real date string is parsed to a date object."""
+        player = Player.model_validate({"birthdate": "1995-02-14"})
+        assert player.birthdate == dt.date(1995, 2, 14)
+
+    @staticmethod
+    def test_valid_datetime_parsed() -> None:
+        """Verify a real datetime string is parsed to a datetime object."""
+        match = Match.model_validate({"date": "2019-04-27 15:46:00"})
+        assert match.date == dt.datetime(2019, 4, 27, 15, 46, 0)
+
+    @staticmethod
+    def test_multiple_date_fields() -> None:
+        """Verify null date conversion works across multiple date fields."""
+        player = Player.model_validate({"birthdate": "0000-01-01", "deathdate": "0000-01-01"})
+        assert player.birthdate is None
+        assert player.deathdate is None
+
+    @staticmethod
+    def test_squad_player_dates() -> None:
+        """Verify SquadPlayer date fields are normalized correctly."""
+        sp = SquadPlayer.model_validate(
+            {
+                "joindate": "2019-05-01",
+                "leavedate": "0000-01-01",
+                "inactivedate": "",
+            }
+        )
+        assert sp.joindate == dt.date(2019, 5, 1)
+        assert sp.leavedate is None
+        assert sp.inactivedate is None
+
+
+# === Model-Specific Parsing ===
+
+
+class TestPlayerModel:
+    """Tests for the Player model."""
+
+    SAMPLE: ClassVar[dict[str, object]] = {
+        "pageid": 100007,
+        "pagename": "Aonir",
+        "namespace": 0,
+        "objectname": "100007_staff_Aonir",
+        "id": "Aonir",
+        "alternateid": "",
+        "name": "Carolin Hanisch",
+        "type": "staff",
+        "nationality": "Germany",
+        "nationality2": "",
+        "nationality3": "",
+        "region": "Europe",
+        "birthdate": "0000-01-01",
+        "deathdate": "0000-01-01",
+        "status": "Inactive",
+        "earnings": 0,
+        "earningsbyyear": [],
+        "links": {"twitter": "https://twitter.com/Aon1r"},
+        "extradata": {"role": "observer"},
+        "wiki": "dota2",
+    }
+
+    def test_parses_sample(self) -> None:
+        """Verify Player correctly parses a real API response dict."""
+        player = Player.model_validate(self.SAMPLE)
+        assert player.id == "Aonir"
+        assert player.name == "Carolin Hanisch"
+        assert player.nationality == "Germany"
+        assert player.birthdate is None
+        assert player.earnings == 0
+        assert player.wiki == "dota2"
+        assert player.links == {"twitter": "https://twitter.com/Aon1r"}
+
+
+class TestTeamModel:
+    """Tests for the Team model."""
+
+    SAMPLE: ClassVar[dict[str, object]] = {
+        "pageid": 100223,
+        "pagename": "Beastcoast",
+        "name": "beastcoast",
+        "region": "South America",
+        "status": "disbanded",
+        "createdate": "2017-07-02",
+        "disbanddate": "2024-12-05",
+        "earnings": 2079695,
+        "earningsbyyear": {"2024": 290912, "2021": 674550},
+        "template": "beastcoast",
+        "links": {"twitter": "https://twitter.com/beastcoast"},
+        "wiki": "dota2",
+    }
+
+    def test_parses_sample(self) -> None:
+        """Verify Team correctly parses a real API response dict."""
+        team = Team.model_validate(self.SAMPLE)
+        assert team.name == "beastcoast"
+        assert team.createdate == dt.date(2017, 7, 2)
+        assert team.disbanddate == dt.date(2024, 12, 5)
+        assert team.earnings == 2079695
+        assert team.status == "disbanded"
+
+
+class TestMatchModel:
+    """Tests for the Match model."""
+
+    SAMPLE: ClassVar[dict[str, object]] = {
+        "pageid": 100012,
+        "match2id": "vlvyfJG3PQ_R01-M001",
+        "winner": "2",
+        "finished": 1,
+        "bestof": 1,
+        "date": "2019-04-27 15:46:00",
+        "dateexact": 1,
+        "tournament": "Epulze Monthly Cup April 2019",
+        "match2opponents": [{"name": "Team A"}, {"name": "Team B"}],
+        "wiki": "dota2",
+    }
+
+    def test_parses_sample(self) -> None:
+        """Verify Match correctly parses a real API response dict."""
+        match = Match.model_validate(self.SAMPLE)
+        assert match.match2id == "vlvyfJG3PQ_R01-M001"
+        assert match.winner == "2"
+        assert match.finished == 1
+        assert match.bestof == 1
+        assert match.date == dt.datetime(2019, 4, 27, 15, 46, 0)
+        assert match.match2opponents == [{"name": "Team A"}, {"name": "Team B"}]
+
+
+class TestTournamentModel:
+    """Tests for the Tournament model."""
+
+    SAMPLE: ClassVar[dict[str, object]] = {
+        "pageid": 100012,
+        "name": "Epulze Monthly Cup April 2019",
+        "startdate": "2019-04-27",
+        "enddate": "2019-04-27",
+        "prizepool": 500,
+        "participantsnumber": 65,
+        "liquipediatier": "4",
+        "wiki": "dota2",
+    }
+
+    def test_parses_sample(self) -> None:
+        """Verify Tournament correctly parses a real API response dict."""
+        tournament = Tournament.model_validate(self.SAMPLE)
+        assert tournament.name == "Epulze Monthly Cup April 2019"
+        assert tournament.startdate == dt.date(2019, 4, 27)
+        assert tournament.prizepool == 500
+        assert tournament.participantsnumber == 65
+
+
+# === Team Template Models ===
+
+
+class TestTeamTemplateModels:
+    """Tests for TeamTemplate and TeamTemplateList models."""
+
+    SAMPLE: ClassVar[dict[str, object]] = {
+        "template": "teamliquid",
+        "page": "TeamLiquid",
+        "name": "TeamLiquid",
+        "shortname": "TL",
+        "bracketname": "TeamLiquid",
+        "image": "TL_logo.png",
+        "imageurl": "https://example.com/tl.png",
+    }
+
+    def test_team_template_parses(self) -> None:
+        """Verify TeamTemplate correctly parses a sample dict."""
+        tt = TeamTemplate.model_validate(self.SAMPLE)
+        assert tt.template == "teamliquid"
+        assert tt.name == "TeamLiquid"
+        assert tt.imageurl == "https://example.com/tl.png"
+
+    def test_team_template_list_parses(self) -> None:
+        """Verify TeamTemplateList correctly parses a sample dict."""
+        ttl = TeamTemplateList.model_validate(self.SAMPLE)
+        assert ttl.template == "teamliquid"
+
+    @staticmethod
+    def test_not_lpdb_model_subclass() -> None:
+        """Verify team template models do not inherit from _LpdbModel."""
+        assert not issubclass(TeamTemplate, _LpdbModel)
+        assert not issubclass(TeamTemplateList, _LpdbModel)
+        assert issubclass(TeamTemplate, _TeamTemplateBase)
+        assert issubclass(TeamTemplateList, _TeamTemplateBase)
+
+    @staticmethod
+    def test_no_pageid_field() -> None:
+        """Verify team template models do not have pageid as a declared field."""
+        assert "pageid" not in TeamTemplate.model_fields
+        assert "wiki" not in TeamTemplate.model_fields
+
+
+# === Exports ===
+
+
+class TestExports:
+    """Tests for model exports in __init__."""
+
+    @staticmethod
+    @pytest.mark.parametrize("model_cls", ALL_MODELS, ids=lambda m: m.__name__)
+    def test_model_in_all(model_cls: type) -> None:
+        """Verify each model is listed in __all__."""
+        assert model_cls.__name__ in liquipydia.__all__
+
+    @staticmethod
+    def test_private_bases_not_in_all() -> None:
+        """Verify private base classes are not in __all__."""
+        assert "_LpdbModel" not in liquipydia.__all__
+        assert "_TeamTemplateBase" not in liquipydia.__all__

--- a/liquipydia/__init__.py
+++ b/liquipydia/__init__.py
@@ -9,6 +9,24 @@ from liquipydia._exceptions import (  # skipcq: PY-W2000
     NotFoundError,
     RateLimitError,
 )
+from liquipydia._models import (  # skipcq: PY-W2000
+    Broadcaster,
+    Company,
+    Datapoint,
+    ExternalMediaLink,
+    Match,
+    Placement,
+    Player,
+    Series,
+    SquadPlayer,
+    StandingsEntry,
+    StandingsTable,
+    Team,
+    TeamTemplate,
+    TeamTemplateList,
+    Tournament,
+    Transfer,
+)
 from liquipydia._resources import (  # skipcq: PY-W2000
     BroadcastersResource,
     CompaniesResource,
@@ -30,7 +48,7 @@ from liquipydia._resources import (  # skipcq: PY-W2000
 )
 from liquipydia._response import ApiResponse  # skipcq: PY-W2000
 
-__version__ = "0.0.3"
+__version__ = "0.0.4"
 __author__ = "Dylan Monfret"
 
 __all__: list[str] = [
@@ -41,6 +59,23 @@ __all__: list[str] = [
     "LiquipediaClient",
     # Response
     "ApiResponse",
+    # Models
+    "Broadcaster",
+    "Company",
+    "Datapoint",
+    "ExternalMediaLink",
+    "Match",
+    "Placement",
+    "Player",
+    "Series",
+    "SquadPlayer",
+    "StandingsEntry",
+    "StandingsTable",
+    "Team",
+    "TeamTemplate",
+    "TeamTemplateList",
+    "Tournament",
+    "Transfer",
     # Resources
     "BroadcastersResource",
     "CompaniesResource",

--- a/liquipydia/_client.py
+++ b/liquipydia/_client.py
@@ -34,7 +34,7 @@ from liquipydia._response import ApiResponse
 
 # === Constants ===
 
-_VERSION: Final[str] = "0.0.3"
+_VERSION: Final[str] = "0.0.4"
 _BASE_URL: Final[str] = "https://api.liquipedia.net/api/v3/"
 _ENV_API_KEY: Final[str] = "LIQUIPEDIA_API_KEY"
 _MAX_BACKOFF: Final[float] = 60.0

--- a/liquipydia/_models.py
+++ b/liquipydia/_models.py
@@ -1,0 +1,425 @@
+"""Pydantic models for LPDB v3 API response records."""
+
+# Standard library
+import datetime as dt
+from typing import Annotated, Any
+
+# Third-party
+from pydantic import BaseModel, BeforeValidator, ConfigDict
+
+# === Helpers ===
+
+_NULL_DATE_PREFIX = "0000-01-01"
+
+
+def _coerce_null_date(v: object) -> object:
+    """Convert LPDB null-date sentinels to ``None``.
+
+    The API uses ``"0000-01-01"`` and empty strings as placeholders for unknown dates.
+    """
+    if isinstance(v, str) and (not v or v.startswith(_NULL_DATE_PREFIX)):
+        return None
+    return v
+
+
+def _coerce_empty_list_to_none(v: object) -> object:
+    """Convert empty lists to ``None``.
+
+    The API returns ``[]`` instead of ``{}`` or ``null`` for empty dict-like fields.
+    """
+    if isinstance(v, list) and len(v) == 0:
+        return None
+    return v
+
+
+NullableDate = Annotated[dt.date | None, BeforeValidator(_coerce_null_date)]
+"""A ``date`` field that converts LPDB null sentinels (``"0000-01-01"``, ``""``) to ``None``."""
+
+NullableDatetime = Annotated[dt.datetime | None, BeforeValidator(_coerce_null_date)]
+"""A ``datetime`` field that converts LPDB null sentinels (``"0000-01-01 00:00:00"``, ``""``) to ``None``."""
+
+LpdbDict = Annotated[dict[str, Any] | None, BeforeValidator(_coerce_empty_list_to_none)]
+"""A ``dict`` field that converts empty API lists (``[]``) to ``None``."""
+
+
+# === Base Models ===
+
+
+class _LpdbModel(BaseModel):
+    """Base model for LPDB v3 response records.
+
+    Provides common fields shared across most endpoints and allows extra fields
+    since the API schema is not fully documented.
+    """
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    pageid: int | None = None
+    pagename: str | None = None
+    namespace: int | None = None
+    objectname: str | None = None
+    wiki: str | None = None
+
+
+class _TeamTemplateBase(BaseModel):
+    """Base model for team template records.
+
+    Team template endpoints return a different field set from standard endpoints
+    (no ``pageid``, ``namespace``, ``objectname``, or ``wiki``).
+    """
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    template: str | None = None
+    page: str | None = None
+    name: str | None = None
+    shortname: str | None = None
+    bracketname: str | None = None
+    image: str | None = None
+    imagedark: str | None = None
+    legacyimage: str | None = None
+    legacyimagedark: str | None = None
+    imageurl: str | None = None
+    imagedarkurl: str | None = None
+    legacyimageurl: str | None = None
+    legacyimagedarkurl: str | None = None
+
+
+# === Models ===
+
+
+class Broadcaster(_LpdbModel):
+    """A broadcaster record from the ``/broadcasters`` endpoint."""
+
+    id: str | None = None
+    name: str | None = None
+    page: str | None = None
+    position: str | None = None
+    language: str | None = None
+    flag: str | None = None
+    weight: int | None = None
+    date: NullableDate = None
+    parent: str | None = None
+    extradata: LpdbDict = None
+
+
+class Company(_LpdbModel):
+    """A company record from the ``/company`` endpoint."""
+
+    name: str | None = None
+    image: str | None = None
+    imageurl: str | None = None
+    imagedark: str | None = None
+    imagedarkurl: str | None = None
+    locations: LpdbDict = None
+    parentcompany: str | None = None
+    sistercompany: str | None = None
+    industry: str | None = None
+    foundeddate: NullableDatetime = None
+    defunctdate: NullableDatetime = None
+    defunctfate: str | None = None
+    links: LpdbDict = None
+    extradata: LpdbDict = None
+
+
+class Datapoint(_LpdbModel):
+    """A datapoint record from the ``/datapoint`` endpoint."""
+
+    type: str | None = None
+    name: str | None = None
+    information: str | None = None
+    image: str | None = None
+    imageurl: str | None = None
+    imagedark: str | None = None
+    imagedarkurl: str | None = None
+    date: NullableDatetime = None
+    extradata: LpdbDict = None
+
+
+class ExternalMediaLink(_LpdbModel):
+    """An external media link record from the ``/externalmedialink`` endpoint."""
+
+    title: str | None = None
+    translatedtitle: str | None = None
+    link: str | None = None
+    date: NullableDate = None
+    authors: LpdbDict = None
+    language: str | None = None
+    publisher: str | None = None
+    type: str | None = None
+    extradata: dict[str, Any] | list[Any] | None = None
+
+
+class Match(_LpdbModel):
+    """A match record from the ``/match`` endpoint."""
+
+    match2id: str | None = None
+    match2bracketid: str | None = None
+    status: str | None = None
+    winner: str | None = None
+    walkover: str | None = None
+    resulttype: str | None = None
+    finished: int | None = None
+    mode: str | None = None
+    type: str | None = None
+    section: str | None = None
+    game: str | None = None
+    patch: str | None = None
+    date: NullableDatetime = None
+    dateexact: int | None = None
+    stream: dict[str, Any] | list[Any] | None = None
+    links: LpdbDict = None
+    bestof: int | None = None
+    vod: str | None = None
+    tournament: str | None = None
+    parent: str | None = None
+    tickername: str | None = None
+    shortname: str | None = None
+    series: str | None = None
+    icon: str | None = None
+    iconurl: str | None = None
+    icondark: str | None = None
+    icondarkurl: str | None = None
+    liquipediatier: str | None = None
+    liquipediatiertype: str | None = None
+    publishertier: str | None = None
+    extradata: LpdbDict = None
+    match2bracketdata: LpdbDict = None
+    match2opponents: list[Any] | None = None
+    match2games: list[Any] | None = None
+
+
+class Placement(_LpdbModel):
+    """A placement record from the ``/placement`` endpoint."""
+
+    tournament: str | None = None
+    series: str | None = None
+    parent: str | None = None
+    imageurl: str | None = None
+    imagedarkurl: str | None = None
+    startdate: NullableDatetime = None
+    date: NullableDatetime = None
+    placement: str | None = None
+    prizemoney: int | None = None
+    individualprizemoney: int | None = None
+    prizepoolindex: int | None = None
+    weight: float | None = None
+    mode: str | None = None
+    type: str | None = None
+    liquipediatier: str | None = None
+    liquipediatiertype: str | None = None
+    publishertier: str | None = None
+    icon: str | None = None
+    iconurl: str | None = None
+    icondark: str | None = None
+    icondarkurl: str | None = None
+    game: str | None = None
+    lastvsdata: LpdbDict = None
+    opponentname: str | None = None
+    opponenttemplate: str | None = None
+    opponenttype: str | None = None
+    opponentplayers: LpdbDict = None
+    qualifier: str | None = None
+    qualifierpage: str | None = None
+    qualifierurl: str | None = None
+    extradata: LpdbDict = None
+
+
+class Player(_LpdbModel):
+    """A player record from the ``/player`` endpoint."""
+
+    id: str | None = None
+    alternateid: str | None = None
+    name: str | None = None
+    localizedname: str | None = None
+    type: str | None = None
+    nationality: str | None = None
+    nationality2: str | None = None
+    nationality3: str | None = None
+    region: str | None = None
+    birthdate: NullableDate = None
+    deathdate: NullableDate = None
+    teampagename: str | None = None
+    teamtemplate: str | None = None
+    links: LpdbDict = None
+    status: str | None = None
+    earnings: int | None = None
+    earningsbyyear: dict[str, Any] | list[Any] | None = None
+    extradata: LpdbDict = None
+
+
+class Series(_LpdbModel):
+    """A series record from the ``/series`` endpoint."""
+
+    name: str | None = None
+    abbreviation: str | None = None
+    image: str | None = None
+    imageurl: str | None = None
+    imagedark: str | None = None
+    imagedarkurl: str | None = None
+    icon: str | None = None
+    iconurl: str | None = None
+    icondark: str | None = None
+    icondarkurl: str | None = None
+    game: str | None = None
+    type: str | None = None
+    organizers: LpdbDict = None
+    locations: LpdbDict = None
+    prizepool: float | None = None
+    liquipediatier: str | None = None
+    liquipediatiertype: str | None = None
+    publishertier: str | None = None
+    launcheddate: NullableDate = None
+    defunctdate: NullableDate = None
+    defunctfate: str | None = None
+    links: LpdbDict = None
+    extradata: LpdbDict = None
+
+
+class SquadPlayer(_LpdbModel):
+    """A squad player record from the ``/squadplayer`` endpoint."""
+
+    id: str | None = None
+    link: str | None = None
+    name: str | None = None
+    nationality: str | None = None
+    position: str | None = None
+    role: str | None = None
+    type: str | None = None
+    newteam: str | None = None
+    teamtemplate: str | None = None
+    newteamtemplate: str | None = None
+    status: str | None = None
+    joindate: NullableDate = None
+    joindateref: str | None = None
+    leavedate: NullableDate = None
+    leavedateref: str | None = None
+    inactivedate: NullableDate = None
+    inactivedateref: str | None = None
+    extradata: LpdbDict = None
+
+
+class StandingsEntry(_LpdbModel):
+    """A standings entry record from the ``/standingsentry`` endpoint."""
+
+    parent: str | None = None
+    standingsindex: int | None = None
+    opponenttype: str | None = None
+    opponentname: str | None = None
+    opponenttemplate: str | None = None
+    opponentplayers: LpdbDict = None
+    placement: int | None = None
+    definitestatus: str | None = None
+    currentstatus: str | None = None
+    placementchange: int | None = None
+    scoreboard: LpdbDict = None
+    roundindex: int | None = None
+    slotindex: int | None = None
+    extradata: LpdbDict = None
+
+
+class StandingsTable(_LpdbModel):
+    """A standings table record from the ``/standingstable`` endpoint."""
+
+    parent: str | None = None
+    standingsindex: int | None = None
+    title: str | None = None
+    tournament: str | None = None
+    section: str | None = None
+    type: str | None = None
+    matches: dict[str, Any] | list[Any] | None = None
+    config: dict[str, Any] | list[Any] | None = None
+    extradata: LpdbDict = None
+
+
+class Team(_LpdbModel):
+    """A team record from the ``/team`` endpoint."""
+
+    name: str | None = None
+    locations: LpdbDict = None
+    region: str | None = None
+    logo: str | None = None
+    logourl: str | None = None
+    logodark: str | None = None
+    logodarkurl: str | None = None
+    textlesslogourl: str | None = None
+    textlesslogodarkurl: str | None = None
+    status: str | None = None
+    createdate: NullableDate = None
+    disbanddate: NullableDate = None
+    earnings: int | None = None
+    earningsbyyear: LpdbDict = None
+    template: str | None = None
+    links: LpdbDict = None
+    extradata: LpdbDict = None
+
+
+class Tournament(_LpdbModel):
+    """A tournament record from the ``/tournament`` endpoint."""
+
+    name: str | None = None
+    shortname: str | None = None
+    tickername: str | None = None
+    banner: str | None = None
+    bannerurl: str | None = None
+    bannerdark: str | None = None
+    bannerdarkurl: str | None = None
+    icon: str | None = None
+    iconurl: str | None = None
+    icondark: str | None = None
+    icondarkurl: str | None = None
+    seriespage: str | None = None
+    serieslist: LpdbDict = None
+    previous: str | None = None
+    previous2: str | None = None
+    next: str | None = None
+    next2: str | None = None
+    game: str | None = None
+    mode: str | None = None
+    patch: str | None = None
+    endpatch: str | None = None
+    type: str | None = None
+    organizers: str | None = None
+    startdate: NullableDate = None
+    enddate: NullableDate = None
+    sortdate: NullableDate = None
+    locations: LpdbDict = None
+    prizepool: float | None = None
+    participantsnumber: int | None = None
+    liquipediatier: str | None = None
+    liquipediatiertype: str | None = None
+    publishertier: str | None = None
+    status: str | None = None
+    maps: str | None = None
+    format: str | None = None
+    sponsors: str | None = None
+    extradata: LpdbDict = None
+
+
+class Transfer(_LpdbModel):
+    """A transfer record from the ``/transfer`` endpoint."""
+
+    staticid: str | None = None
+    player: str | None = None
+    nationality: str | None = None
+    fromteam: str | None = None
+    toteam: str | None = None
+    fromteamtemplate: str | None = None
+    toteamtemplate: str | None = None
+    role1: str | None = None
+    role2: str | None = None
+    reference: LpdbDict = None
+    date: NullableDatetime = None
+    wholeteam: int | None = None
+    extradata: LpdbDict = None
+
+
+# === Team Template Models ===
+
+
+class TeamTemplate(_TeamTemplateBase):
+    """A team template record from the ``/teamtemplate`` endpoint."""
+
+
+class TeamTemplateList(_TeamTemplateBase):
+    """A team template list record from the ``/teamtemplatelist`` endpoint."""

--- a/liquipydia/_models.py
+++ b/liquipydia/_models.py
@@ -199,7 +199,7 @@ class Placement(_LpdbModel):
     imagedarkurl: str | None = None
     startdate: NullableDatetime = None
     date: NullableDatetime = None
-    placement: str | None = None
+    placement: str | None = None  # skipcq: PTC-W0052 — field name matches API response key
     prizemoney: int | None = None
     individualprizemoney: int | None = None
     prizepoolindex: int | None = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "liquipydia"
-version = "0.0.3"
+version = "0.0.4"
 description = "Python client library for the Liquipedia API (LPDB v3)."
 readme = "README.md"
 license = "MIT"
@@ -36,11 +36,9 @@ Changelog = "https://github.com/Dyl-M/liquipydia/blob/main/CHANGELOG.md"
 
 [dependency-groups]
 dev = [
-    "pytest==9.0.2",
-    "respx==0.22.0",
+    { include-group = "test" },
     "ruff==0.15.9",
     "mypy==1.20.0",
-    "coverage==7.13.5",
 ]
 test = [
     "pytest==9.0.2",


### PR DESCRIPTION
## Summary

Implement the v0.0.4 milestone — one Pydantic model per LPDB v3 data type, giving users typed access to API fields with IDE autocompletion and automatic handling of LPDB quirks (null date sentinels, empty list placeholders). Models are standalone — users call `Model.model_validate(record)` on dicts from `ApiResponse.result`, fully backward compatible.

## Changes

### Models (`liquipydia/_models.py`)

* 16 Pydantic models: `Broadcaster`, `Company`, `Datapoint`, `ExternalMediaLink`, `Match`, `Placement`, `Player`, `Series`, `SquadPlayer`, `StandingsEntry`, `StandingsTable`, `Team`, `Tournament`, `Transfer`, `TeamTemplate`, `TeamTemplateList`
* Private base class `_LpdbModel` with common fields (`pageid`, `pagename`, `namespace`, `objectname`, `wiki`)
* Private base class `_TeamTemplateBase` for team template endpoints (different field set, no `pageid`/`wiki`)
* All fields `type | None = None` — fully optional, forward-compatible
* `ConfigDict(extra="allow", populate_by_name=True)` — unknown/future API fields preserved

### Reusable type aliases

* `NullableDate` — `Annotated[date | None, BeforeValidator]`, converts LPDB null sentinels (`"0000-01-01"`, `""`) to `None`
* `NullableDatetime` — same for datetime fields (`"0000-01-01 00:00:00"`)
* `LpdbDict` — `Annotated[dict | None, BeforeValidator]`, converts empty API lists (`[]`) to `None`

### Package updates

* Re-export all 16 models from `__init__.py`, update `__all__`
* Bump version to `0.0.4` (`pyproject.toml`, `__init__.py`, `_client.py`)
* Refactor `dev` dependency group to use `include-group = "test"` instead of duplicating deps

### Tests

* `test_models.py` — base model construction, extra field preservation, empty list coercion (`LpdbDict`), null date sentinel conversion, valid date/datetime parsing, model-specific sample parsing (Player, Team, Match, Tournament), team template inheritance, `__all__` exports
* `test_init.py` — version assertion updated to `0.0.4`

### Documentation

* README: added `_models.py` to project structure, updated Quick Start to show typed model usage, added "Typed Models"  section
* Roadmap: marked all v0.0.4 items complete, checked off existing unit test items in v0.0.5

## Validation steps before merge

- [x] Lint & Test CI OK (no regression)
- [x] DeepSource health check OK (no regression)
- [x] Human review completed (post-changes made by DeepSource or automated tools)
