### PR TITLE
tests, docs: integration tests and Sphinx documentation site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,56 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build Documentation
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync --group docs
+
+      - name: Build Sphinx docs
+        run: uv run sphinx-build -b html _docs/sphinx _docs/sphinx/_build/html
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: _docs/sphinx/_build/html
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/license_workflow.yml
+++ b/.github/workflows/license_workflow.yml
@@ -1,4 +1,4 @@
-name: Update License years
+name: Update License & Copyright years
 
 on:
   workflow_dispatch:
@@ -20,6 +20,11 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.PAT }}
+
+      - name: Update Sphinx copyright year
+        run: |
+          YEAR=$(date +%Y)
+          sed -i "s/copyright = \"[0-9]\\{4\\},/copyright = \"$YEAR,/" _docs/sphinx/conf.py
 
       - uses: FantasticFiasco/action-update-license-year@v3
         with:

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -78,6 +78,8 @@ jobs:
         run: uv sync --group test
 
       - name: Run tests with coverage
+        env:
+          LPDB_API_KEY: ${{ secrets.LPDB_API_KEY }}
         run: uv run coverage run -m pytest
 
       - name: Coverage report

--- a/.gitignore
+++ b/.gitignore
@@ -211,3 +211,6 @@ __marimo__/
 .tokens/
 _drafts/
 CLAUDE.md
+
+# Sphinx build output
+_docs/sphinx/_build*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.5] - 2026-04-10
+
+### Added
+
+- Integration test suite in `_tests/test_integration.py` with `@pytest.mark.integration` marker (auto-skips when no
+  API key is available; resolves key from `LPDB_API_KEY` env var or `.tokens/tokens.json`)
+- Sphinx + Furo documentation site in `_docs/sphinx/` with Liquipedia-themed colors, autodoc API reference,
+  getting-started guide, examples with output blocks, and changelog page
+- Jinja2 template override for clickable author name in Furo footer
+- GitHub Pages deployment workflow (`.github/workflows/docs.yml`, triggers on push to `main`)
+- `LPDB_API_KEY` secret as env var in CI test job for integration tests
+- Sphinx copyright year update step in license workflow (renamed to "Update License & Copyright years")
+- Documentation section in README linking to GitHub Pages site
+- Output blocks (`text` code fences) to code examples in README, getting-started, examples, and index pages
+- Post-release section in roadmap with conda-forge package goal
+
+### Changed
+
+- Switch documentation stack from mkdocs-material + mkdocstrings to Sphinx 9 + Furo + myst-parser +
+  sphinx-autodoc-typehints + sphinx-copybutton + sphinx-autobuild
+- Move documentation source from `docs/` to `_docs/sphinx/`
+- Replace static `_LpdbModel` field table in models reference with autodoc directives for both base classes
+- Update roadmap with completed v0.0.5 items
+
+### Fixed
+
+- Remove incorrect `endpoint` parameter from `Resource` class docstring `Args:` section
+
 ## [0.0.4] - 2026-04-06
 
 ### Added
@@ -109,7 +137,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Downgrade `astral-sh/setup-uv` from v8 to v7 (v8 major tag does not exist)
 - Enforce docstrings in test suite (remove pydocstyle exemption for `_tests/`)
 
-[Unreleased]: https://github.com/Dyl-M/liquipydia/compare/v0.0.4...dev
+[Unreleased]: https://github.com/Dyl-M/liquipydia/compare/v0.0.5...dev
+
+[0.0.5]: https://github.com/Dyl-M/liquipydia/compare/v0.0.4...v0.0.5
 
 [0.0.4]: https://github.com/Dyl-M/liquipydia/compare/v0.0.3...v0.0.4
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ with LiquipediaClient("my-app", api_key="your-api-key") as client:
     response = client.team_templates.get("dota2", "teamliquid")
 ```
 
+```text
+Miracle- Jordan 1997-06-20
+0042_R01-M001 2025-06-15 14:00:00 1
+...
+```
+
 ### Available Resources
 
 All 16 LPDB v3 data types are accessible as client attributes:
@@ -120,11 +126,22 @@ print(player.birthdate)  # date | None — null sentinels auto-converted
 print(player.links)  # dict | None — empty API lists auto-converted
 ```
 
+```text
+Miracle-
+1997-06-20
+{'twitter': 'https://twitter.com/Aborss', ...}
+```
+
 Models handle LPDB quirks automatically:
 
 - Null date sentinels (`"0000-01-01"`, `""`) → `None`
 - Empty dict placeholders (`[]`) → `None`
 - Unknown/future API fields are preserved (`extra="allow"`)
+
+## Documentation
+
+Full documentation (getting started, examples, API reference) is available at
+**[dyl-m.github.io/liquipydia](https://dyl-m.github.io/liquipydia/)**.
 
 ## Development
 

--- a/_docs/ROADMAP.md
+++ b/_docs/ROADMAP.md
@@ -113,11 +113,16 @@ Typed response models for IDE autocompletion and validation. One model per data 
 - [x] Unit tests for client (request building, headers, error handling) using `respx` to mock `httpx`
 - [x] Unit tests for each resource (parameter construction, response parsing)
 - [x] Unit tests for Pydantic models (validation, edge cases)
-- [ ] Integration test suite (opt-in, requires real API key, skipped in CI by default)
-- [ ] `mkdocs-material` documentation site
+- [x] Integration test suite (opt-in, requires real API key via `LPDB_API_KEY` env var or `.tokens/tokens.json`;
+  `@pytest.mark.integration` marker, auto-skips when no key is available)
+- [x] Sphinx + Furo documentation site (`_docs/sphinx/`)
     - Getting started / quickstart
-    - API reference (auto-generated from docstrings)
-    - Examples per resource
+    - API reference (auto-generated from docstrings via `autodoc` + `napoleon` + `sphinx-autodoc-typehints`)
+    - Examples per resource with output blocks
+    - Changelog (included from root `CHANGELOG.md`)
+    - Liquipedia-themed colors, clickable author footer
+- [x] GitHub Pages deployment workflow (`.github/workflows/docs.yml`, triggers on push to `main`)
+- [x] CI integration tests (LPDB_API_KEY secret in GitHub Actions test job)
 
 ## v0.1.0 — First public release
 
@@ -126,6 +131,10 @@ First PyPI release covering the full LPDB v3 surface.
 - [ ] PyPI publish workflow (GitHub Actions, trusted publishing)
 - [ ] `CHANGELOG.md` entry
 - [ ] GitHub Release with notes
+
+## Post-release
+
+- [ ] conda-forge package (submit recipe to `conda-forge/staged-recipes`, auto-rebuilds on PyPI releases)
 
 ## Future / Out of scope for v1
 

--- a/_docs/sphinx/_templates/page.html
+++ b/_docs/sphinx/_templates/page.html
@@ -1,0 +1,5 @@
+{% extends "!page.html" %}
+
+{% block footer %}
+{{ super() | replace("Dylan Monfret @Dyl-M", '<a href="https://github.com/Dyl-M">Dylan Monfret @Dyl-M</a>') }}
+{% endblock %}

--- a/_docs/sphinx/api/client.rst
+++ b/_docs/sphinx/api/client.rst
@@ -1,0 +1,22 @@
+Client
+======
+
+The main entry point for interacting with the Liquipedia API.
+
+After construction, access data through resource attributes (e.g. ``client.players``,
+``client.matches``). See :doc:`resources` for the full list.
+
+.. autoclass:: liquipydia.LiquipediaClient
+   :members: __init__, close, __enter__, __exit__
+
+Low-level methods
+-----------------
+
+These methods are used internally by resource classes. You typically don't need to call them
+directly — use the resource ``list()`` and ``paginate()`` methods instead.
+
+.. automethod:: liquipydia.LiquipediaClient.get
+   :no-index:
+
+.. automethod:: liquipydia.LiquipediaClient.paginate
+   :no-index:

--- a/_docs/sphinx/api/exceptions.rst
+++ b/_docs/sphinx/api/exceptions.rst
@@ -1,0 +1,20 @@
+Exceptions
+==========
+
+All exceptions inherit from :class:`~liquipydia.LiquipediaError`, so you can catch it as a
+base class for any library error.
+
+.. autoclass:: liquipydia.LiquipediaError
+   :members:
+
+.. autoclass:: liquipydia.AuthError
+   :members:
+
+.. autoclass:: liquipydia.NotFoundError
+   :members:
+
+.. autoclass:: liquipydia.RateLimitError
+   :members:
+
+.. autoclass:: liquipydia.ApiError
+   :members:

--- a/_docs/sphinx/api/models.rst
+++ b/_docs/sphinx/api/models.rst
@@ -1,0 +1,103 @@
+:tocdepth: 3
+
+Models
+======
+
+Pydantic models for typed access to API response records. Use ``Model.model_validate(record)``
+on dicts from :class:`~liquipydia.ApiResponse`.
+
+All fields are optional (``type | None = None``) for forward compatibility. Unknown API fields
+are preserved via ``extra="allow"``.
+
+Type aliases
+------------
+
+These handle LPDB API quirks automatically:
+
+- **NullableDate** — converts null sentinels (``"0000-01-01"``, ``""``) to ``None``
+- **NullableDatetime** — same for datetime fields (``"0000-01-01 00:00:00"``)
+- **LpdbDict** — converts empty API lists (``[]``) to ``None`` for dict-like fields
+
+Base classes
+------------
+
+Most models inherit from ``_LpdbModel``, which provides common fields shared across standard
+endpoints. Team template models use ``_TeamTemplateBase`` instead (different field set).
+
+.. autoclass:: liquipydia._models._LpdbModel
+   :members:
+   :inherited-members: BaseModel
+
+.. autoclass:: liquipydia._models._TeamTemplateBase
+   :members:
+   :inherited-members: BaseModel
+
+Standard models
+---------------
+
+.. autoclass:: liquipydia.Broadcaster
+   :members:
+   :inherited-members: BaseModel
+
+.. autoclass:: liquipydia.Company
+   :members:
+   :inherited-members: BaseModel
+
+.. autoclass:: liquipydia.Datapoint
+   :members:
+   :inherited-members: BaseModel
+
+.. autoclass:: liquipydia.ExternalMediaLink
+   :members:
+   :inherited-members: BaseModel
+
+.. autoclass:: liquipydia.Match
+   :members:
+   :inherited-members: BaseModel
+
+.. autoclass:: liquipydia.Placement
+   :members:
+   :inherited-members: BaseModel
+
+.. autoclass:: liquipydia.Player
+   :members:
+   :inherited-members: BaseModel
+
+.. autoclass:: liquipydia.Series
+   :members:
+   :inherited-members: BaseModel
+
+.. autoclass:: liquipydia.SquadPlayer
+   :members:
+   :inherited-members: BaseModel
+
+.. autoclass:: liquipydia.StandingsEntry
+   :members:
+   :inherited-members: BaseModel
+
+.. autoclass:: liquipydia.StandingsTable
+   :members:
+   :inherited-members: BaseModel
+
+.. autoclass:: liquipydia.Team
+   :members:
+   :inherited-members: BaseModel
+
+.. autoclass:: liquipydia.Tournament
+   :members:
+   :inherited-members: BaseModel
+
+.. autoclass:: liquipydia.Transfer
+   :members:
+   :inherited-members: BaseModel
+
+Team template models
+--------------------
+
+.. autoclass:: liquipydia.TeamTemplate
+   :members:
+   :inherited-members: BaseModel
+
+.. autoclass:: liquipydia.TeamTemplateList
+   :members:
+   :inherited-members: BaseModel

--- a/_docs/sphinx/api/resources.rst
+++ b/_docs/sphinx/api/resources.rst
@@ -1,0 +1,69 @@
+Resources
+=========
+
+Resource classes wrap individual LPDB v3 endpoints. Each resource is accessible as an attribute on
+:class:`~liquipydia.LiquipediaClient`.
+
+Base class
+----------
+
+.. autoclass:: liquipydia.Resource
+   :members: list, paginate
+
+Standard resources
+------------------
+
+These resources inherit ``list()`` and ``paginate()`` from ``Resource`` without modifications.
+
+.. autoclass:: liquipydia.BroadcastersResource
+
+.. autoclass:: liquipydia.CompaniesResource
+
+.. autoclass:: liquipydia.DatapointsResource
+
+.. autoclass:: liquipydia.ExternalMediaLinksResource
+
+.. autoclass:: liquipydia.PlacementsResource
+
+.. autoclass:: liquipydia.PlayersResource
+
+.. autoclass:: liquipydia.SeriesResource
+
+.. autoclass:: liquipydia.SquadPlayersResource
+
+.. autoclass:: liquipydia.StandingsEntriesResource
+
+.. autoclass:: liquipydia.StandingsTablesResource
+
+.. autoclass:: liquipydia.TeamsResource
+
+.. autoclass:: liquipydia.TournamentsResource
+
+.. autoclass:: liquipydia.TransfersResource
+
+Specialized resources
+---------------------
+
+MatchResource
+^^^^^^^^^^^^^
+
+Inherits ``list()`` and ``paginate()`` from ``Resource``. The ``rawstreams`` and ``streamurls``
+parameters are only meaningful on this endpoint.
+
+.. autoclass:: liquipydia.MatchResource
+
+TeamTemplateResource
+^^^^^^^^^^^^^^^^^^^^
+
+Different API signature — uses ``get()`` instead of ``list()``.
+
+.. autoclass:: liquipydia.TeamTemplateResource
+   :members: get
+
+TeamTemplateListResource
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Different API signature — uses ``pagination`` parameter instead of ``limit``/``offset``.
+
+.. autoclass:: liquipydia.TeamTemplateListResource
+   :members: list

--- a/_docs/sphinx/api/response.rst
+++ b/_docs/sphinx/api/response.rst
@@ -1,0 +1,4 @@
+Response
+========
+
+.. autoclass:: liquipydia.ApiResponse

--- a/_docs/sphinx/changelog.md
+++ b/_docs/sphinx/changelog.md
@@ -1,0 +1,2 @@
+```{include} ../../CHANGELOG.md
+```

--- a/_docs/sphinx/conf.py
+++ b/_docs/sphinx/conf.py
@@ -1,0 +1,99 @@
+"""Sphinx configuration for the liquipydia documentation."""
+
+# -- Project information -----------------------------------------------------
+
+project = "liquipydia"
+author = "Dylan Monfret"
+# noinspection PyShadowingBuiltins
+copyright = "2026, Dylan Monfret @Dyl-M"
+
+# -- General configuration ---------------------------------------------------
+
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.intersphinx",
+    "sphinx_autodoc_typehints",
+    "sphinx_copybutton",
+    "myst_parser",
+]
+
+templates_path = ["_templates"]
+
+# -- Options for autodoc -----------------------------------------------------
+
+autodoc_member_order = "bysource"
+autodoc_default_options = {
+    "members": True,
+    "undoc-members": False,
+    "show-inheritance": True,
+}
+autodoc_typehints = "signature"
+autodoc_class_signature = "separated"
+
+# -- Options for Napoleon (Google-style docstrings) --------------------------
+
+napoleon_google_docstring = True
+napoleon_numpy_docstring = False
+
+# -- Options for sphinx-autodoc-typehints ------------------------------------
+
+typehints_defaults = "braces"
+always_use_bars_union = True
+
+# -- Options for MyST (Markdown support) -------------------------------------
+
+myst_enable_extensions = [
+    "colon_fence",
+    "deflist",
+]
+
+# -- Options for intersphinx -------------------------------------------------
+
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+}
+
+# -- Options for HTML output -------------------------------------------------
+
+html_theme = "furo"
+html_title = "liquipydia"
+
+html_theme_options = {
+    "source_repository": "https://github.com/Dyl-M/liquipydia",
+    "source_branch": "main",
+    "source_directory": "_docs/sphinx/",
+    "light_css_variables": {
+        "color-brand-primary": "#072B4B",
+        "color-brand-content": "#0A3D6B",
+        "color-sidebar-brand-text": "#072B4B",
+        "color-sidebar-link-text--top-level": "#072B4B",
+        "color-link": "#0A3D6B",
+        "color-link--hover": "#072B4B",
+    },
+    "dark_css_variables": {
+        "color-brand-primary": "#5BA3D9",
+        "color-brand-content": "#7BB8E3",
+        "color-sidebar-brand-text": "#5BA3D9",
+        "color-sidebar-link-text--top-level": "#5BA3D9",
+        "color-link": "#7BB8E3",
+        "color-link--hover": "#5BA3D9",
+    },
+}
+
+html_sidebars = {
+    "**": [
+        "sidebar/brand.html",
+        "sidebar/search.html",
+        "sidebar/scroll-start.html",
+        "sidebar/navigation.html",
+        "sidebar/scroll-end.html",
+    ],
+}
+
+# -- Source file suffixes ----------------------------------------------------
+
+source_suffix = {
+    ".rst": "restructuredtext",
+    ".md": "markdown",
+}

--- a/_docs/sphinx/examples.md
+++ b/_docs/sphinx/examples.md
@@ -1,0 +1,252 @@
+# Examples
+
+All examples assume you have a `LiquipediaClient` instance:
+
+```python
+from liquipydia import LiquipediaClient
+
+client = LiquipediaClient("my-app", api_key="your-api-key")
+```
+
+```{tip}
+Use the client as a context manager to ensure the HTTP session is properly closed:
+
+    with LiquipediaClient("my-app", api_key="your-api-key") as client:
+        ...
+```
+
+## Standard resources
+
+Most resources share the same `list()` and `paginate()` interface. Here are some examples using
+`players`, but the same pattern applies to `broadcasters`, `companies`, `datapoints`,
+`external_media_links`, `placements`, `series`, `squad_players`, `standings_entries`,
+`standings_tables`, `teams`, `tournaments`, and `transfers`.
+
+### Basic query
+
+```python
+from liquipydia import Player
+
+response = client.players.list("dota2", limit=10)
+
+for record in response.result:
+    player = Player.model_validate(record)
+    print(player.name, player.nationality)
+```
+
+```text
+Miracle- Jordan
+SumaiL Pakistan
+...
+```
+
+### LPDB conditions
+
+```python
+response = client.players.list(
+    "counterstrike",
+    conditions="[[nationality::Denmark]] AND [[status::Active]]",
+    limit=20,
+)
+```
+
+### Keyword filters
+
+Instead of writing raw LPDB condition strings, use keyword arguments:
+
+```python
+# Simple equality
+response = client.players.list("rocketleague", pagename="Zen")
+
+# Operator prefixes: > (greater), < (less), ! (not)
+response = client.tournaments.list("dota2", liquipediatier="1", prizepool=">100000")
+```
+
+Keyword filters can be combined with explicit `conditions`:
+
+```python
+response = client.players.list(
+    "counterstrike",
+    conditions="[[status::Active]]",
+    nationality="Denmark",
+)
+```
+
+### Selecting fields
+
+Use the `query` parameter to return only specific fields:
+
+```python
+response = client.players.list("dota2", query="pagename,name,nationality", limit=5)
+```
+
+### Ordering and grouping
+
+```python
+response = client.tournaments.list("dota2", order="startdate DESC", limit=10)
+```
+
+### Multi-wiki queries
+
+Pipe-separate wiki names to query across multiple games:
+
+```python
+response = client.players.list("dota2|counterstrike", limit=10)
+```
+
+## Pagination
+
+The `paginate()` method handles offset management automatically, yielding individual records:
+
+```python
+from liquipydia import Match
+
+# Get up to 500 matches, 100 per page
+for record in client.matches.paginate("counterstrike", page_size=100, max_results=500):
+    match = Match.model_validate(record)
+    print(match.match2id, match.date)
+```
+
+```text
+0042_R01-M001 2025-06-15 14:00:00
+0042_R01-M002 2025-06-15 15:30:00
+...
+```
+
+Without `max_results`, pagination continues until no more results are returned:
+
+```python
+# Iterate through ALL players (use with caution)
+for record in client.players.paginate("rocketleague", page_size=200):
+    player = Player.model_validate(record)
+    print(player.name)
+```
+
+```text
+Zen
+Vatira
+...
+```
+
+## Matches (stream data)
+
+The match resource supports two extra parameters for stream data:
+
+```python
+from liquipydia import Match
+
+response = client.matches.list(
+    "rocketleague",
+    rawstreams=True,
+    streamurls=True,
+    limit=5,
+)
+
+for record in response.result:
+    match = Match.model_validate(record)
+    print(match.match2id, match.stream)
+```
+
+```text
+0001_R01-M001 {'twitch': 'rocketleague', 'youtube': '...'}
+0001_R01-M002 {'twitch': 'rocketleague'}
+...
+```
+
+These parameters also work with `paginate()`:
+
+```python
+for record in client.matches.paginate("dota2", rawstreams=True, max_results=50):
+    match = Match.model_validate(record)
+    print(match.match2id, match.stream)
+```
+
+```text
+0001_R01-M001 {'twitch': 'daboross', 'youtube': '...'}
+...
+```
+
+```{note}
+`rawstreams` and `streamurls` are accepted on all resources but only meaningful for the `/match`
+endpoint. On other resources, they are silently ignored.
+```
+
+## Team templates
+
+Team template endpoints have a different API signature from standard resources.
+
+### Single lookup
+
+```python
+from liquipydia import TeamTemplate
+
+response = client.team_templates.get("dota2", "teamliquid")
+
+for record in response.result:
+    if record is not None:
+        template = TeamTemplate.model_validate(record)
+        print(template.name, template.shortname)
+```
+
+```text
+Team Liquid TL
+```
+
+Use the `date` parameter for historical logos:
+
+```python
+response = client.team_templates.get("dota2", "teamliquid", date="2020-01-01")
+```
+
+### Listing all templates
+
+```python
+from liquipydia import TeamTemplateList
+
+response = client.team_template_list.list("rocketleague")
+
+for record in response.result:
+    if record is not None:
+        template = TeamTemplateList.model_validate(record)
+        print(template.template, template.name)
+```
+
+```text
+teamliquid Team Liquid
+g2esports G2 Esports
+...
+```
+
+Use `pagination` for page-based navigation:
+
+```python
+# Get page 2
+response = client.team_template_list.list("rocketleague", pagination=2)
+```
+
+## Error handling
+
+```python
+from liquipydia import (
+    LiquipediaClient,
+    AuthError,
+    NotFoundError,
+    RateLimitError,
+    ApiError,
+    LiquipediaError,
+)
+
+with LiquipediaClient("my-app", api_key="your-api-key") as client:
+    try:
+        response = client.players.list("dota2")
+    except AuthError:
+        print("Invalid or missing API key")
+    except NotFoundError:
+        print("Requested data does not exist")
+    except RateLimitError as e:
+        print(f"Rate limited — retry after {e.retry_after}s")
+    except ApiError as e:
+        print(f"API error: {e.message}")
+    except LiquipediaError as e:
+        print(f"Unexpected error: {e.message}")
+```

--- a/_docs/sphinx/getting-started.md
+++ b/_docs/sphinx/getting-started.md
@@ -1,0 +1,95 @@
+# Getting Started
+
+## API access
+
+Using this library requires an API key from Liquipedia. Access is **not self-service** — you must request it through
+their [contact form](https://liquipedia.net/api).
+
+Free access is available for **educational**, **non-commercial open-source**, and **community** projects.
+Paid plans (Basic, Premium, Enterprise) are available for commercial use.
+
+## Installation
+
+```{note}
+Not yet published on PyPI. Install from source for now.
+```
+
+With uv (recommended):
+
+```bash
+uv add git+https://github.com/Dyl-M/liquipydia.git
+```
+
+With pip:
+
+```bash
+pip install git+https://github.com/Dyl-M/liquipydia.git
+```
+
+## Authentication
+
+Pass your API key directly or set it as an environment variable:
+
+```python
+from liquipydia import LiquipediaClient
+
+# Option 1: pass directly
+client = LiquipediaClient("my-app", api_key="your-api-key")
+
+# Option 2: environment variable
+# export LIQUIPEDIA_API_KEY=your-api-key
+client = LiquipediaClient("my-app")
+```
+
+## Quickstart
+
+```python
+from liquipydia import LiquipediaClient, Player, Match
+
+with LiquipediaClient("my-app", api_key="your-api-key") as client:
+    # Query players from a specific wiki
+    response = client.players.list("dota2", pagename="Miracle-")
+    for record in response.result:
+        player = Player.model_validate(record)
+        print(player.name, player.nationality, player.birthdate)
+
+    # Automatic pagination across multiple pages
+    for record in client.matches.paginate("counterstrike", page_size=100, max_results=500):
+        match = Match.model_validate(record)
+        print(match.match2id, match.date, match.winner)
+
+    # Keyword filters — no need to write raw LPDB conditions
+    response = client.players.list("rocketleague", pagename="Zen")
+
+    # Team template lookup
+    response = client.team_templates.get("dota2", "teamliquid")
+```
+
+```text
+Miracle- Jordan 1997-06-20
+0042_R01-M001 2025-06-15 14:00:00 1
+...
+```
+
+## Available resources
+
+All 16 LPDB v3 data types are accessible as client attributes:
+
+| Attribute                     | Endpoint             | Notes                             |
+|-------------------------------|----------------------|-----------------------------------|
+| `client.broadcasters`         | `/broadcasters`      |                                   |
+| `client.companies`            | `/company`           |                                   |
+| `client.datapoints`           | `/datapoint`         |                                   |
+| `client.external_media_links` | `/externalmedialink` |                                   |
+| `client.matches`              | `/match`             | Extra: `rawstreams`, `streamurls` |
+| `client.placements`           | `/placement`         |                                   |
+| `client.players`              | `/player`            |                                   |
+| `client.series`               | `/series`            |                                   |
+| `client.squad_players`        | `/squadplayer`       |                                   |
+| `client.standings_entries`    | `/standingsentry`    |                                   |
+| `client.standings_tables`     | `/standingstable`    |                                   |
+| `client.teams`                | `/team`              |                                   |
+| `client.tournaments`          | `/tournament`        |                                   |
+| `client.transfers`            | `/transfer`          |                                   |
+| `client.team_templates`       | `/teamtemplate`      | Uses `get()` instead of `list()`  |
+| `client.team_template_list`   | `/teamtemplatelist`  | Different params (`pagination`)   |

--- a/_docs/sphinx/index.rst
+++ b/_docs/sphinx/index.rst
@@ -1,0 +1,67 @@
+liquipydia
+==========
+
+**A modern, typed Python client for the Liquipedia API (LPDB v3).**
+
+liquipydia is a Python client library for the `Liquipedia <https://liquipedia.net/>`_ Database
+(LPDB) REST API v3, covering all 16 data types (matches, tournaments, teams, players, transfers,
+and more).
+
+Built with `httpx <https://www.python-httpx.org/>`_ and `pydantic <https://docs.pydantic.dev/>`_.
+
+Features
+--------
+
+- **Full LPDB v3 coverage** — all 16 data types accessible as client attributes
+- **Typed models** — Pydantic models for every data type with IDE autocompletion
+- **Automatic pagination** — iterate through results without manual offset management
+- **Keyword filters** — Pythonic query syntax instead of raw LPDB condition strings
+- **Rate limit handling** — automatic retries with exponential backoff on HTTP 429
+- **Context manager** — clean resource management with ``with`` statement
+
+Quick example
+-------------
+
+.. code-block:: python
+
+   from liquipydia import LiquipediaClient, Player
+
+   with LiquipediaClient("my-app", api_key="your-api-key") as client:
+       response = client.players.list("dota2", pagename="Miracle-")
+       for record in response.result:
+           player = Player.model_validate(record)
+           print(player.name, player.nationality)
+
+.. code-block:: text
+
+   Miracle- Jordan
+
+.. toctree::
+   :maxdepth: 2
+   :caption: User Guide
+
+   getting-started
+   examples
+
+.. toctree::
+   :maxdepth: 2
+   :caption: API Reference
+
+   api/client
+   api/resources
+   api/models
+   api/response
+   api/exceptions
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Project
+
+   changelog
+
+Data license
+------------
+
+Data returned by the Liquipedia API is subject to
+`CC-BY-SA 3.0 <https://creativecommons.org/licenses/by-sa/3.0/>`_ as required by Liquipedia's
+`API Terms of Use <https://liquipedia.net/api-terms-of-use>`_.

--- a/_tests/test_integration.py
+++ b/_tests/test_integration.py
@@ -1,0 +1,153 @@
+"""Integration tests that hit the live Liquipedia API.
+
+These tests are opt-in: they require a valid API key via the ``LPDB_API_KEY``
+environment variable or the ``.tokens/tokens.json`` file (``repo_key`` field).
+Tests are automatically skipped when no key is available.
+"""
+
+# Standard library
+import json
+import os
+from pathlib import Path
+
+# Third-party
+import pytest
+
+# Local
+from liquipydia import (
+    ApiResponse,
+    LiquipediaClient,
+    Match,
+    Player,
+    TeamTemplate,
+    TeamTemplateList,
+    Tournament,
+)
+
+# === Constants ===
+
+_WIKI = "rocketleague"
+_TOKENS_PATH = Path(__file__).resolve().parent.parent / ".tokens" / "tokens.json"
+
+
+# === Helpers ===
+
+
+def _resolve_api_key() -> str | None:
+    """Resolve the API key from environment variable or local tokens file."""
+    key = os.environ.get("LPDB_API_KEY")
+    if key:
+        return key
+
+    if _TOKENS_PATH.is_file():
+        tokens = json.loads(_TOKENS_PATH.read_text(encoding="utf-8"))
+        return tokens.get("repo_key")
+
+    return None
+
+
+_API_KEY = _resolve_api_key()
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(not _API_KEY, reason="No API key (set LPDB_API_KEY or provide .tokens/tokens.json)"),
+]
+
+
+def _make_client() -> LiquipediaClient:
+    """Create a client configured for integration testing."""
+    assert _API_KEY is not None
+    return LiquipediaClient("liquipydia-integration-tests", api_key=_API_KEY, timeout=30.0)
+
+
+# === Tests ===
+
+
+class TestIntegration:
+    """Integration tests against the live Liquipedia API."""
+
+    def test_players_list(self) -> None:
+        """Standard resource list returns parseable results."""
+        with _make_client() as client:
+            response = client.players.list(_WIKI, limit=5)
+
+        assert isinstance(response, ApiResponse)
+        assert len(response.result) > 0
+
+        for record in response.result:
+            Player.model_validate(record)
+
+    def test_tournaments_list(self) -> None:
+        """Another standard resource returns parseable results."""
+        with _make_client() as client:
+            response = client.tournaments.list(_WIKI, limit=5)
+
+        assert isinstance(response, ApiResponse)
+        assert len(response.result) > 0
+
+        for record in response.result:
+            Tournament.model_validate(record)
+
+    def test_matches_list(self) -> None:
+        """Match resource returns parseable results."""
+        with _make_client() as client:
+            response = client.matches.list(_WIKI, limit=5)
+
+        assert isinstance(response, ApiResponse)
+        assert len(response.result) > 0
+
+        for record in response.result:
+            Match.model_validate(record)
+
+    def test_matches_with_streams(self) -> None:
+        """Match resource with rawstreams and streamurls parameters."""
+        with _make_client() as client:
+            response = client.matches.list(_WIKI, limit=5, rawstreams=True, streamurls=True)
+
+        assert isinstance(response, ApiResponse)
+        assert len(response.result) > 0
+
+        for record in response.result:
+            Match.model_validate(record)
+
+    def test_team_template_get(self) -> None:
+        """TeamTemplateResource.get() with different API signature."""
+        with _make_client() as client:
+            response = client.team_templates.get(_WIKI, "team liquid")
+
+        assert isinstance(response, ApiResponse)
+        records = [r for r in response.result if r is not None]
+        assert len(records) > 0
+
+        TeamTemplate.model_validate(records[0])
+
+    def test_team_template_list(self) -> None:
+        """TeamTemplateListResource.list() returns parseable results."""
+        with _make_client() as client:
+            response = client.team_template_list.list(_WIKI)
+
+        assert isinstance(response, ApiResponse)
+        records = [r for r in response.result if r is not None]
+        assert len(records) > 0
+
+        for record in records:
+            TeamTemplateList.model_validate(record)
+
+    def test_pagination(self) -> None:
+        """Pagination yields the expected number of records."""
+        with _make_client() as client:
+            records = list(client.players.paginate(_WIKI, page_size=2, max_results=5))
+
+        assert len(records) == 5
+
+        for record in records:
+            Player.model_validate(record)
+
+    def test_keyword_filter(self) -> None:
+        """Keyword filter narrows results."""
+        with _make_client() as client:
+            response = client.teams.list(_WIKI, pagename="Moist_Esports")
+
+        assert isinstance(response, ApiResponse)
+        assert len(response.result) > 0
+        assert response.result[0]["pagename"] == "Moist_Esports"

--- a/_tests/test_integration.py
+++ b/_tests/test_integration.py
@@ -66,7 +66,8 @@ def _make_client() -> LiquipediaClient:
 class TestIntegration:
     """Integration tests against the live Liquipedia API."""
 
-    def test_players_list(self) -> None:
+    @staticmethod
+    def test_players_list() -> None:
         """Standard resource list returns parseable results."""
         with _make_client() as client:
             response = client.players.list(_WIKI, limit=5)
@@ -77,7 +78,8 @@ class TestIntegration:
         for record in response.result:
             Player.model_validate(record)
 
-    def test_tournaments_list(self) -> None:
+    @staticmethod
+    def test_tournaments_list() -> None:
         """Another standard resource returns parseable results."""
         with _make_client() as client:
             response = client.tournaments.list(_WIKI, limit=5)
@@ -88,7 +90,8 @@ class TestIntegration:
         for record in response.result:
             Tournament.model_validate(record)
 
-    def test_matches_list(self) -> None:
+    @staticmethod
+    def test_matches_list() -> None:
         """Match resource returns parseable results."""
         with _make_client() as client:
             response = client.matches.list(_WIKI, limit=5)
@@ -99,7 +102,8 @@ class TestIntegration:
         for record in response.result:
             Match.model_validate(record)
 
-    def test_matches_with_streams(self) -> None:
+    @staticmethod
+    def test_matches_with_streams() -> None:
         """Match resource with rawstreams and streamurls parameters."""
         with _make_client() as client:
             response = client.matches.list(_WIKI, limit=5, rawstreams=True, streamurls=True)
@@ -110,7 +114,8 @@ class TestIntegration:
         for record in response.result:
             Match.model_validate(record)
 
-    def test_team_template_get(self) -> None:
+    @staticmethod
+    def test_team_template_get() -> None:
         """TeamTemplateResource.get() with different API signature."""
         with _make_client() as client:
             response = client.team_templates.get(_WIKI, "team liquid")
@@ -121,7 +126,8 @@ class TestIntegration:
 
         TeamTemplate.model_validate(records[0])
 
-    def test_team_template_list(self) -> None:
+    @staticmethod
+    def test_team_template_list() -> None:
         """TeamTemplateListResource.list() returns parseable results."""
         with _make_client() as client:
             response = client.team_template_list.list(_WIKI)
@@ -133,7 +139,8 @@ class TestIntegration:
         for record in records:
             TeamTemplateList.model_validate(record)
 
-    def test_pagination(self) -> None:
+    @staticmethod
+    def test_pagination() -> None:
         """Pagination yields the expected number of records."""
         with _make_client() as client:
             records = list(client.players.paginate(_WIKI, page_size=2, max_results=5))
@@ -143,7 +150,8 @@ class TestIntegration:
         for record in records:
             Player.model_validate(record)
 
-    def test_keyword_filter(self) -> None:
+    @staticmethod
+    def test_keyword_filter() -> None:
         """Keyword filter narrows results."""
         with _make_client() as client:
             response = client.teams.list(_WIKI, pagename="Moist_Esports")

--- a/liquipydia/_resources.py
+++ b/liquipydia/_resources.py
@@ -20,10 +20,11 @@ class Resource:
     """Base resource wrapping a single LPDB v3 endpoint.
 
     Provides ``list`` and ``paginate`` methods that delegate HTTP calls to the parent client.
+    Subclasses set ``_endpoint`` to the API path segment (e.g. ``"player"``).
+
 
     Args:
         client: The parent LiquipediaClient instance.
-        endpoint: API path segment (e.g. ``"player"``).
     """
 
     _endpoint: str

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,8 +46,12 @@ test = [
     "coverage==7.13.5",
 ]
 docs = [
-    "mkdocs-material==9.7.6",
-    "mkdocstrings[python]==1.0.3",
+    "furo==2025.12.19",
+    "myst-parser==5.0.0",
+    "sphinx==9.1.0",
+    "sphinx-autobuild==2025.8.25",
+    "sphinx-autodoc-typehints==3.10.0",
+    "sphinx-copybutton==0.5.2"
 ]
 
 # --- Ruff ---
@@ -118,6 +122,7 @@ warn_required_dynamic_aliases = true
 testpaths = ["_tests"]
 pythonpath = ["."]
 addopts = "-v --strict-markers --tb=short"
+markers = ["integration: opt-in tests that hit the live Liquipedia API (requires LPDB_API_KEY)"]
 
 # --- Coverage ---
 


### PR DESCRIPTION
## Summary

Complete the v0.0.5 milestone — an opt-in integration test suite that hits the live Liquipedia API, and a full documentation site built with Sphinx + Furo, deployed to GitHub Pages.

## Changes

### Integration tests (`_tests/test_integration.py`)

* 8 tests covering players, tournaments, matches (with stream data), team templates, pagination, and keyword filters
* `@pytest.mark.integration` marker with auto-skip when no API key is available
* Key resolution: `LPDB_API_KEY` env var with fallback to `.tokens/tokens.json`
* Filters `None` entries from team template results (known LPDB API quirk)

### Sphinx documentation (`_docs/sphinx/`)

* Sphinx + Furo configuration with Liquipedia-themed colors (`#072B4B` primary)
* User guide pages: getting started, examples with `text` output blocks, changelog (included from root `CHANGELOG.md`)
* API reference pages: client, resources, models (with autodoc for `_LpdbModel` and `_TeamTemplateBase` base classes), response, exceptions
* Jinja2 template override for clickable author name in Furo footer
* Explicit `html_sidebars` config for persistent navigation across all pages
* `:tocdepth: 3` on models page to show class names without individual attributes in the "On this page" sidebar

### CI & workflows

* New `docs.yml` workflow: Sphinx build + GitHub Pages deployment on push to `main`
* `lint-and-test.yml`: add `LPDB_API_KEY` secret as env var for integration tests in CI
* `license_workflow.yml`: also update Sphinx `copyright` year via `sed`, rename to "Update License & Copyright years"

### Build & dependencies (`pyproject.toml`)

* Register `integration` marker in pytest config
* Replace `mkdocs-material` + `mkdocstrings` with `sphinx`, `furo`, `myst-parser`, `sphinx-autodoc-typehints`,
  `sphinx-copybutton`, `sphinx-autobuild`

### Other

* `README.md`: add output blocks to code examples, add Documentation section linking to GitHub Pages
* `_docs/ROADMAP.md`: mark v0.0.5 items complete, update doc tooling description, add post-release conda-forge item
* `liquipydia/_resources.py`: fix `Resource` class docstring (move endpoint description out of `Args:`)
* `.gitignore`: add `_docs/sphinx/_build*/` pattern

## Validation steps before merge

- [x] Lint & Test CI OK (no regression)
- [x] Human review completed (post-changes made by DeepSource or automated tools)
