### PR TITLE
release: v0.1.0 — First public release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,54 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [ published ]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  build:
+    name: Build Distributions
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Build sdist and wheel
+        run: uv build
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+
+    environment:
+      name: pypi
+      url: https://pypi.org/project/liquipydia/
+
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PyPI publish workflow (`.github/workflows/publish.yml`) using GitHub Actions trusted publishing (OIDC) — triggers on
   GitHub Release creation
 - Documentation URL in `pyproject.toml` project metadata
+- Filter key validation on `Resource.list()` and `Resource.paginate()` — unknown keys raise `ValueError` with the list
+  of valid fields, validated against each resource's Pydantic model
+- "Development Commands" section in `CONTRIBUTING.md` with lint, format, type check, test, coverage, and docs commands
 
 ### Changed
 
 - Bump version to 0.1.0 — first public PyPI release
 - Update development status classifier from "Planning" to "Beta"
 - Update installation instructions in README and Sphinx docs to use PyPI (`pip install liquipydia`)
+- Update README status badge and label from "early development" to "beta"
+
+### Fixed
+
+- Harden response parsing and retry backoff logic in `LiquipediaClient`
+- Validate filter key format with regex before checking against model fields
+- Add rate limit delay (10s) between integration tests to prevent API throttling in CI
 
 ## [0.0.5] - 2026-04-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,10 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Switch documentation stack from mkdocs-material + mkdocstrings to Sphinx 9 + Furo + myst-parser +
+- Bump version to 0.0.5
+- Switch documentation dependencies from mkdocs-material + mkdocstrings to Sphinx 9 + Furo + myst-parser +
   sphinx-autodoc-typehints + sphinx-copybutton + sphinx-autobuild
-- Move documentation source from `docs/` to `_docs/sphinx/`
-- Replace static `_LpdbModel` field table in models reference with autodoc directives for both base classes
 - Update roadmap with completed v0.0.5 items
 
 ### Fixed
@@ -131,11 +130,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `.deepsource.toml` for static analysis and test coverage reporting
 - `.gitattributes` with LF line ending normalization
 - `CHANGELOG.md` (this file)
-
-### Fixed
-
-- Downgrade `astral-sh/setup-uv` from v8 to v7 (v8 major tag does not exist)
-- Enforce docstrings in test suite (remove pydocstyle exemption for `_tests/`)
 
 [Unreleased]: https://github.com/Dyl-M/liquipydia/compare/v0.0.5...dev
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-04-11
+
+### Added
+
+- PyPI publish workflow (`.github/workflows/publish.yml`) using GitHub Actions trusted publishing (OIDC) — triggers on
+  GitHub Release creation
+- Documentation URL in `pyproject.toml` project metadata
+
+### Changed
+
+- Bump version to 0.1.0 — first public PyPI release
+- Update development status classifier from "Planning" to "Beta"
+- Update installation instructions in README and Sphinx docs to use PyPI (`pip install liquipydia`)
+
 ## [0.0.5] - 2026-04-10
 
 ### Added
@@ -131,7 +145,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `.gitattributes` with LF line ending normalization
 - `CHANGELOG.md` (this file)
 
-[Unreleased]: https://github.com/Dyl-M/liquipydia/compare/v0.0.5...dev
+[Unreleased]: https://github.com/Dyl-M/liquipydia/compare/v0.1.0...dev
+
+[0.1.0]: https://github.com/Dyl-M/liquipydia/compare/v0.0.5...v0.1.0
 
 [0.0.5]: https://github.com/Dyl-M/liquipydia/compare/v0.0.4...v0.0.5
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,35 @@ Thanks for your interest in contributing to **`liquipydia`**! Here are a few gui
    git checkout -b your-branch-name dev
    ```
 
-3. Make your changes, then push to your fork and open a pull request targeting `dev`.
+3. Install all development dependencies:
+
+   ```bash
+   uv sync --group dev
+   ```
+
+4. Make your changes, then push to your fork and open a pull request targeting `dev`.
+
+## Development Commands
+
+```bash
+# Lint & format
+uv run ruff check .              # lint
+uv run ruff format --check .     # format check
+uv run ruff check --fix .        # auto-fix lint issues
+uv run ruff format .             # auto-format
+
+# Type check
+uv run mypy liquipydia
+
+# Tests
+uv run pytest                                            # full test suite
+uv run coverage run -m pytest && uv run coverage report  # with coverage
+
+# Documentation
+uv sync --group docs                                               # install docs dependencies
+uv run sphinx-build -b html _docs/sphinx _docs/sphinx/_build/html  # one-off build
+uv run sphinx-autobuild _docs/sphinx _docs/sphinx/_build/html      # live preview with hot reload
+```
 
 ## Branch Strategy
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 ![License](https://img.shields.io/github/license/Dyl-M/liquipydia)
 
-![Status](https://img.shields.io/badge/status-early%20development-orange?style=flat-square)
+![Status](https://img.shields.io/badge/status-beta-green?style=flat-square)
 [![Lint & Test](https://img.shields.io/github/actions/workflow/status/Dyl-M/liquipydia/lint-and-test.yml?label=Lint%20%26%20Test&style=flat-square&logo=github-actions&logoColor=white)](https://github.com/Dyl-M/liquipydia/actions/workflows/lint-and-test.yml)
 [![DeepSource](https://app.deepsource.com/gh/Dyl-M/liquipydia.svg/?label=active+issues&show_trend=true&token=TOKEN)](https://app.deepsource.com/gh/Dyl-M/liquipydia/)
 [![DeepSource](https://app.deepsource.com/gh/Dyl-M/liquipydia.svg/?label=code+coverage&show_trend=true&token=TOKEN)](https://app.deepsource.com/gh/Dyl-M/liquipydia/)
@@ -17,7 +17,7 @@
 
 Built with [`httpx`](https://www.python-httpx.org/) and [`pydantic`](https://docs.pydantic.dev/).
 
-> **Status:** Early development — see the [Roadmap](_docs/ROADMAP.md) for progress.
+> **Status:** Beta — see the [Roadmap](_docs/ROADMAP.md) for progress.
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -42,10 +42,18 @@ Paid plans (Basic, Premium, Enterprise) are available for commercial use.
 
 ## Installation
 
-> **Note:** Not yet published on PyPI. Install from source for now.
-
 ```bash
 # With uv (recommended)
+uv add liquipydia
+
+# With pip
+pip install liquipydia
+```
+
+Or install from source:
+
+```bash
+# With uv
 uv add git+https://github.com/Dyl-M/liquipydia.git
 
 # With pip

--- a/_docs/ROADMAP.md
+++ b/_docs/ROADMAP.md
@@ -63,22 +63,22 @@ Each resource exposes:
 
 ```python
 def list(
-        self, wiki: str, *,
-        conditions: str | None, query: str | None,
-        limit: int = 50, offset: int = 0,
-        order: str | None, groupby: str | None,
-        rawstreams: bool = False, streamurls: bool = False,
-        **filters: str,
+    self, wiki: str, *,
+    conditions: str | None, query: str | None,
+    limit: int = 50, offset: int = 0,
+    order: str | None, groupby: str | None,
+    rawstreams: bool = False, streamurls: bool = False,
+    **filters: str,
 ) -> ApiResponse
 
 
 def paginate(
-        self, wiki: str, *,
-        conditions: str | None, query: str | None,
-        order: str | None, groupby: str | None,
-        rawstreams: bool = False, streamurls: bool = False,
-        page_size: int = 50, max_results: int | None,
-        **filters: str,
+    self, wiki: str, *,
+    conditions: str | None, query: str | None,
+    order: str | None, groupby: str | None,
+    rawstreams: bool = False, streamurls: bool = False,
+    page_size: int = 50, max_results: int | None,
+    **filters: str,
 ) -> Iterator[dict]
 ```
 
@@ -128,8 +128,8 @@ Typed response models for IDE autocompletion and validation. One model per data 
 
 First PyPI release covering the full LPDB v3 surface.
 
-- [ ] PyPI publish workflow (GitHub Actions, trusted publishing)
-- [ ] `CHANGELOG.md` entry
+- [x] PyPI publish workflow (GitHub Actions, trusted publishing)
+- [x] `CHANGELOG.md` entry
 - [ ] GitHub Release with notes
 
 ## Post-release

--- a/_docs/sphinx/getting-started.md
+++ b/_docs/sphinx/getting-started.md
@@ -10,19 +10,25 @@ Paid plans (Basic, Premium, Enterprise) are available for commercial use.
 
 ## Installation
 
-```{note}
-Not yet published on PyPI. Install from source for now.
-```
-
 With uv (recommended):
 
 ```bash
-uv add git+https://github.com/Dyl-M/liquipydia.git
+uv add liquipydia
 ```
 
 With pip:
 
 ```bash
+pip install liquipydia
+```
+
+Or install from source:
+
+```bash
+# With uv
+uv add git+https://github.com/Dyl-M/liquipydia.git
+
+# With pip
 pip install git+https://github.com/Dyl-M/liquipydia.git
 ```
 

--- a/_tests/test_init.py
+++ b/_tests/test_init.py
@@ -10,7 +10,7 @@ def test_version_is_string() -> None:
 
 def test_version_value() -> None:
     """Verify that __version__ matches the expected value."""
-    assert __version__ == "0.0.5"
+    assert __version__ == "0.1.0"
 
 
 def test_author() -> None:

--- a/_tests/test_integration.py
+++ b/_tests/test_integration.py
@@ -9,6 +9,7 @@ Tests are automatically skipped when no key is available.
 import json
 import os
 from pathlib import Path
+import time
 
 # Third-party
 import pytest
@@ -65,6 +66,12 @@ def _make_client() -> LiquipediaClient:
 
 class TestIntegration:
     """Integration tests against the live Liquipedia API."""
+
+    @staticmethod
+    @pytest.fixture(autouse=True)
+    def _rate_limit_delay() -> None:
+        """Pause between tests to avoid hitting the Liquipedia API rate limit."""
+        time.sleep(10)
 
     @staticmethod
     def test_players_list() -> None:

--- a/_tests/test_resources.py
+++ b/_tests/test_resources.py
@@ -269,27 +269,24 @@ class TestKeywordFilters:
         """Verify a filter key with invalid characters raises ValueError."""
         respx.get(f"{BASE_URL}player").mock(return_value=httpx.Response(200, json={"result": []}))
 
-        with _make_client() as client:
-            with pytest.raises(ValueError, match="Invalid filter key"):
-                client.players.list("rocketleague", **{"bad key!": "value"})
+        with _make_client() as client, pytest.raises(ValueError, match="Invalid filter key"):
+            client.players.list("rocketleague", **{"bad key!": "value"})
 
     @respx.mock
     def test_list_rejects_unknown_filter_key(self) -> None:
         """Verify an unknown filter key raises ValueError."""
         respx.get(f"{BASE_URL}player").mock(return_value=httpx.Response(200, json={"result": []}))
 
-        with _make_client() as client:
-            with pytest.raises(ValueError, match="Unknown filter key 'fakefield'"):
-                client.players.list("rocketleague", fakefield="value")
+        with _make_client() as client, pytest.raises(ValueError, match="Unknown filter key 'fakefield'"):
+            client.players.list("rocketleague", fakefield="value")
 
     @respx.mock
     def test_paginate_rejects_unknown_filter_key(self) -> None:
         """Verify an unknown filter key raises ValueError on paginate()."""
         respx.get(f"{BASE_URL}player").mock(return_value=httpx.Response(200, json={"result": []}))
 
-        with _make_client() as client:
-            with pytest.raises(ValueError, match="Unknown filter key 'fakefield'"):
-                list(client.players.paginate("rocketleague", fakefield="value"))
+        with _make_client() as client, pytest.raises(ValueError, match="Unknown filter key 'fakefield'"):
+            list(client.players.paginate("rocketleague", fakefield="value"))
 
 
 # === Match Resource ===

--- a/_tests/test_resources.py
+++ b/_tests/test_resources.py
@@ -5,6 +5,7 @@ from urllib.parse import parse_qs
 
 # Third-party
 import httpx
+import pytest
 import respx
 
 # Local
@@ -262,6 +263,33 @@ class TestKeywordFilters:
         params = _get_query_params(respx.calls.last.request)
         assert params["conditions"] == "[[winner::1]]"
         assert params["rawstreams"] == "true"
+
+    @respx.mock
+    def test_list_rejects_invalid_filter_key(self) -> None:
+        """Verify a filter key with invalid characters raises ValueError."""
+        respx.get(f"{BASE_URL}player").mock(return_value=httpx.Response(200, json={"result": []}))
+
+        with _make_client() as client:
+            with pytest.raises(ValueError, match="Invalid filter key"):
+                client.players.list("rocketleague", **{"bad key!": "value"})
+
+    @respx.mock
+    def test_list_rejects_unknown_filter_key(self) -> None:
+        """Verify an unknown filter key raises ValueError."""
+        respx.get(f"{BASE_URL}player").mock(return_value=httpx.Response(200, json={"result": []}))
+
+        with _make_client() as client:
+            with pytest.raises(ValueError, match="Unknown filter key 'fakefield'"):
+                client.players.list("rocketleague", fakefield="value")
+
+    @respx.mock
+    def test_paginate_rejects_unknown_filter_key(self) -> None:
+        """Verify an unknown filter key raises ValueError on paginate()."""
+        respx.get(f"{BASE_URL}player").mock(return_value=httpx.Response(200, json={"result": []}))
+
+        with _make_client() as client:
+            with pytest.raises(ValueError, match="Unknown filter key 'fakefield'"):
+                list(client.players.paginate("rocketleague", fakefield="value"))
 
 
 # === Match Resource ===

--- a/liquipydia/__init__.py
+++ b/liquipydia/__init__.py
@@ -48,7 +48,7 @@ from liquipydia._resources import (  # skipcq: PY-W2000
 )
 from liquipydia._response import ApiResponse  # skipcq: PY-W2000
 
-__version__ = "0.0.5"
+__version__ = "0.1.0"
 __author__ = "Dylan Monfret"
 
 __all__: list[str] = [

--- a/liquipydia/_client.py
+++ b/liquipydia/_client.py
@@ -34,7 +34,7 @@ from liquipydia._response import ApiResponse
 
 # === Constants ===
 
-_VERSION: Final[str] = "0.0.5"
+_VERSION: Final[str] = "0.1.0"
 _BASE_URL: Final[str] = "https://api.liquipedia.net/api/v3/"
 _ENV_API_KEY: Final[str] = "LIQUIPEDIA_API_KEY"
 _MAX_BACKOFF: Final[float] = 60.0

--- a/liquipydia/_client.py
+++ b/liquipydia/_client.py
@@ -168,7 +168,7 @@ class LiquipediaClient:
             retry_after = self._get_retry_after(response)
             last_retry_after = retry_after
             backoff = min(self._retry_backoff_factor * (2**attempt), _MAX_BACKOFF)
-            sleep_duration: float = retry_after if retry_after > 0 else backoff
+            sleep_duration: float = max(retry_after, backoff) if retry_after > 0 else backoff
 
             if attempt < self._max_retries:
                 time.sleep(sleep_duration)
@@ -200,11 +200,18 @@ class LiquipediaClient:
         if response.status_code >= 400:
             raise LiquipediaError(f"HTTP {response.status_code}: {response.text}")
 
-        body: dict[str, Any] = response.json()
+        try:
+            body = response.json()
+        except Exception as exc:
+            raise LiquipediaError(f"Failed to parse API response: {exc}") from exc
 
-        errors: list[str] = body.get("error", [])
-        if errors:
-            raise ApiError("; ".join(errors))
+        if not isinstance(body, dict):
+            raise LiquipediaError(f"Unexpected API response format: {type(body).__name__}")
+
+        raw_errors = body.get("error", [])
+        if raw_errors:
+            error_list = [raw_errors] if isinstance(raw_errors, str) else list(raw_errors)
+            raise ApiError("; ".join(str(e) for e in error_list))
 
         return ApiResponse(
             result=body.get("result", []),

--- a/liquipydia/_resources.py
+++ b/liquipydia/_resources.py
@@ -3,6 +3,7 @@
 # Standard library
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -148,10 +149,14 @@ class Resource:
         Returns:
             Merged condition string, or ``None`` if both inputs are empty.
         """
+        valid_field = re.compile(r"[a-z_][a-z0-9_]*", re.IGNORECASE)
+
         parts: list[str] = []
         if conditions:
             parts.append(conditions)
         for key, value in filters.items():
+            if not valid_field.fullmatch(key):
+                raise ValueError(f"Invalid filter key: {key!r}")
             parts.append(f"[[{key}::{value}]]")
         return " AND ".join(parts) if parts else None
 

--- a/liquipydia/_resources.py
+++ b/liquipydia/_resources.py
@@ -6,8 +6,29 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Any
 
+# Local
+from liquipydia._models import (
+    Broadcaster,
+    Company,
+    Datapoint,
+    ExternalMediaLink,
+    Match,
+    Placement,
+    Player,
+    Series,
+    SquadPlayer,
+    StandingsEntry,
+    StandingsTable,
+    Team,
+    Tournament,
+    Transfer,
+)
+
 if TYPE_CHECKING:
     from collections.abc import Iterator
+
+    # Third-party
+    from pydantic import BaseModel
 
     # Local
     from liquipydia._client import LiquipediaClient
@@ -21,14 +42,15 @@ class Resource:
     """Base resource wrapping a single LPDB v3 endpoint.
 
     Provides ``list`` and ``paginate`` methods that delegate HTTP calls to the parent client.
-    Subclasses set ``_endpoint`` to the API path segment (e.g. ``"player"``).
-
+    Subclasses set ``_endpoint`` to the API path segment (e.g. ``"player"``) and ``_model``
+    to the corresponding Pydantic model class for filter key validation.
 
     Args:
         client: The parent LiquipediaClient instance.
     """
 
     _endpoint: str
+    _model: type[BaseModel]
 
     def __init__(self, client: LiquipediaClient) -> None:
         self._client = client
@@ -65,7 +87,8 @@ class Resource:
         Returns:
             Parsed API response.
         """
-        merged = self._build_conditions(conditions, filters)
+        valid_fields = frozenset(self._model.model_fields)
+        merged = self._build_conditions(conditions, filters, valid_fields)
         params = self._build_params(
             {
                 "wiki": wiki,
@@ -115,7 +138,8 @@ class Resource:
         Yields:
             Individual record dicts from the API.
         """
-        merged = self._build_conditions(conditions, filters)
+        valid_fields = frozenset(self._model.model_fields)
+        merged = self._build_conditions(conditions, filters, valid_fields)
         params = self._build_params(
             {
                 "wiki": wiki,
@@ -135,7 +159,11 @@ class Resource:
         )
 
     @staticmethod
-    def _build_conditions(conditions: str | None, filters: dict[str, str]) -> str | None:
+    def _build_conditions(
+        conditions: str | None,
+        filters: dict[str, str],
+        valid_fields: frozenset[str] | None = None,
+    ) -> str | None:
         """Merge an explicit conditions string with keyword filters.
 
         Each filter becomes ``[[key::value]]``. Filters are AND-joined with each other
@@ -145,9 +173,14 @@ class Resource:
         Args:
             conditions: Explicit LPDB condition string (can be ``None``).
             filters: Keyword filters to convert (e.g. ``{"name": "Zen"}``).
+            valid_fields: Known model field names for validation. If provided, filter keys
+                not in this set raise ``ValueError``.
 
         Returns:
             Merged condition string, or ``None`` if both inputs are empty.
+
+        Raises:
+            ValueError: If a filter key has invalid characters or is not a known model field.
         """
         valid_field = re.compile(r"[a-z_][a-z0-9_]*", re.IGNORECASE)
 
@@ -157,6 +190,8 @@ class Resource:
         for key, value in filters.items():
             if not valid_field.fullmatch(key):
                 raise ValueError(f"Invalid filter key: {key!r}")
+            if valid_fields is not None and key not in valid_fields:
+                raise ValueError(f"Unknown filter key {key!r} for this resource. Valid keys: {sorted(valid_fields)}")
             parts.append(f"[[{key}::{value}]]")
         return " AND ".join(parts) if parts else None
 
@@ -180,78 +215,91 @@ class BroadcastersResource(Resource):
     """Resource for the ``/broadcasters`` endpoint."""
 
     _endpoint = "broadcasters"
+    _model = Broadcaster
 
 
 class CompaniesResource(Resource):
     """Resource for the ``/company`` endpoint."""
 
     _endpoint = "company"
+    _model = Company
 
 
 class DatapointsResource(Resource):
     """Resource for the ``/datapoint`` endpoint."""
 
     _endpoint = "datapoint"
+    _model = Datapoint
 
 
 class ExternalMediaLinksResource(Resource):
     """Resource for the ``/externalmedialink`` endpoint."""
 
     _endpoint = "externalmedialink"
+    _model = ExternalMediaLink
 
 
 class PlacementsResource(Resource):
     """Resource for the ``/placement`` endpoint."""
 
     _endpoint = "placement"
+    _model = Placement
 
 
 class PlayersResource(Resource):
     """Resource for the ``/player`` endpoint."""
 
     _endpoint = "player"
+    _model = Player
 
 
 class SeriesResource(Resource):
     """Resource for the ``/series`` endpoint."""
 
     _endpoint = "series"
+    _model = Series
 
 
 class SquadPlayersResource(Resource):
     """Resource for the ``/squadplayer`` endpoint."""
 
     _endpoint = "squadplayer"
+    _model = SquadPlayer
 
 
 class StandingsEntriesResource(Resource):
     """Resource for the ``/standingsentry`` endpoint."""
 
     _endpoint = "standingsentry"
+    _model = StandingsEntry
 
 
 class StandingsTablesResource(Resource):
     """Resource for the ``/standingstable`` endpoint."""
 
     _endpoint = "standingstable"
+    _model = StandingsTable
 
 
 class TeamsResource(Resource):
     """Resource for the ``/team`` endpoint."""
 
     _endpoint = "team"
+    _model = Team
 
 
 class TournamentsResource(Resource):
     """Resource for the ``/tournament`` endpoint."""
 
     _endpoint = "tournament"
+    _model = Tournament
 
 
 class TransfersResource(Resource):
     """Resource for the ``/transfer`` endpoint."""
 
     _endpoint = "transfer"
+    _model = Transfer
 
 
 # === Specialized Resources ===
@@ -265,6 +313,7 @@ class MatchResource(Resource):
     """
 
     _endpoint = "match"
+    _model = Match
 
 
 class TeamTemplateResource:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "liquipydia"
-version = "0.0.5"
+version = "0.1.0"
 description = "Python client library for the Liquipedia API (LPDB v3)."
 readme = "README.md"
 license = "MIT"
@@ -14,7 +14,7 @@ authors = [
 ]
 keywords = ["liquipedia", "esports", "api", "api-client", "lpdb"]
 classifiers = [
-    "Development Status :: 1 - Planning",
+    "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
@@ -30,6 +30,7 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://github.com/Dyl-M/liquipydia"
+Documentation = "https://dyl-m.github.io/liquipydia/"
 Repository = "https://github.com/Dyl-M/liquipydia"
 Issues = "https://github.com/Dyl-M/liquipydia/issues"
 Changelog = "https://github.com/Dyl-M/liquipydia/blob/main/CHANGELOG.md"


### PR DESCRIPTION
## Summary

Prepare the first public PyPI release: publish workflow, version bump to 0.1.0, updated install instructions, and resource-layer improvements (filter key validation, hardened client logic).

## Changes

### PyPI publish workflow (`.github/workflows/publish.yml`)

* New workflow triggered on GitHub Release creation
* Two-job pipeline: build (sdist + wheel via `uv build`) → publish (trusted publishing via OIDC)
* Uses `pypi` GitHub environment for deployment protection
* No API token needed — relies on `pypa/gh-action-pypi-publish@release/v1` with `id-token: write`

### Resource filter validation (`liquipydia/_resources.py`)

* Add `_model` class attribute linking each resource to its Pydantic model
* `_build_conditions()` now validates filter keys against known model fields
* Unknown or malformed keys raise `ValueError` with the list of valid alternatives
* Tests for invalid key characters and unknown keys on both `list()` and `paginate()`

### Client hardening (`liquipydia/_client.py`)

* Improve response parsing resilience and retry backoff logic

### Version bump & metadata (`pyproject.toml`, `__init__.py`, `_client.py`)

* Bump version from 0.0.5 to 0.1.0 across all three locations
* Update development status classifier from "Planning" to "Beta"
* Add Documentation URL to project metadata

### Install instructions (`README.md`, `_docs/sphinx/getting-started.md`)

* Replace "not yet published" notice with PyPI install commands (`pip install liquipydia` / `uv add liquipydia`)
* Keep git-from-source as alternative

### Documentation & project docs

* `CHANGELOG.md`: add v0.1.0 entry, update comparison links
* `_docs/ROADMAP.md`: check off completed v0.1.0 items, fix code block indentation
* `CONTRIBUTING.md`: add "Development Commands" section (lint, format, type check, test, coverage, docs preview)

## Validation steps before merge

- [x] Lint & Test CI OK (no regression)
- [x] DeepSource health check OK (no regression)
- [x] Human review completed (post-changes made by DeepSource or automated tools)
