### PR TITLE
ci(release): automatic semantic release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: Semantic Release
+
+on:
+  push:
+    branches: [ main ]
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  release:
+    name: Semantic Release
+    runs-on: ubuntu-latest
+    if: "!startsWith(github.event.head_commit.message, 'chore(release):')"
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.PAT }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Run semantic-release
+        run: |
+          pip install python-semantic-release==9.21.0
+          semantic-release version --push --vcs-release
+        env:
+          GH_TOKEN: ${{ secrets.PAT }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Automatic semantic release workflow (`.github/workflows/release.yml`) using `python-semantic-release` v9 — parses
+  Conventional Commit prefixes to determine version bump, updates all version locations, creates GitHub Release
+- `[tool.semantic_release]` configuration in `pyproject.toml` for version bumping, tagging, and release creation
+- PyPI version badge in README (auto-updates via shields.io)
+- Tests for malformed JSON and non-dict JSON API responses in `TestParseResponse`
+
+### Changed
+
+- Replace hardcoded version assertion in `test_version_value` with semver format regex check
+- Replace relative file links with absolute GitHub URLs in README and CONTRIBUTING to fix broken links on PyPI
+- Reformat README title heading
+- Update roadmap: mark v0.1.0 GitHub Release as complete, add semantic release as post-release item, expand "Future"
+  section with HTTP client dependency evaluation
+
 ## [0.1.0] - 2026-04-11
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,7 +98,7 @@ Use descriptive prefixes:
 ## Reporting Bugs & Requesting Features
 
 - Use the [issue templates](https://github.com/Dyl-M/liquipydia/issues/new/choose) provided in the repository.
-- For security vulnerabilities, follow the process described in [SECURITY.md](SECURITY.md).
+- For security vulnerabilities, follow the process described in [SECURITY.md](https://github.com/Dyl-M/liquipydia/blob/main/SECURITY.md).
 
 ## Code of Conduct
 
@@ -106,4 +106,4 @@ Be respectful and constructive. Harassment or abusive behavior will not be toler
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under the [MIT License](LICENSE).
+By contributing, you agree that your contributions will be licensed under the [MIT License](https://github.com/Dyl-M/liquipydia/blob/main/LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # LIQUIPYDIA | Python client library for [Liquipedia](https://liquipedia.net/) API (LPDB v3)
 
+[![PyPI](https://img.shields.io/pypi/v/liquipydia?logo=pypi&logoColor=white)](https://pypi.org/project/liquipydia/)
 ![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue?logo=python&logoColor=white)
 [![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# `liquipydia` — Python client library for [Liquipedia](https://liquipedia.net/) API (LPDB v3)
+# LIQUIPYDIA | Python client library for [Liquipedia](https://liquipedia.net/) API (LPDB v3)
 
 ![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue?logo=python&logoColor=white)
 [![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
@@ -17,7 +17,7 @@
 
 Built with [`httpx`](https://www.python-httpx.org/) and [`pydantic`](https://docs.pydantic.dev/).
 
-> **Status:** Beta — see the [Roadmap](_docs/ROADMAP.md) for progress.
+> **Status:** Beta — see the [Roadmap](https://github.com/Dyl-M/liquipydia/blob/main/_docs/ROADMAP.md) for progress.
 
 ## Project Structure
 
@@ -174,7 +174,7 @@ uv run pytest
 
 ## License
 
-Code is licensed under the [MIT License](LICENSE).
+Code is licensed under the [MIT License](https://github.com/Dyl-M/liquipydia/blob/main/LICENSE).
 
 ## Data License
 
@@ -185,8 +185,8 @@ through this library, you must comply with the CC-BY-SA 3.0 attribution requirem
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+See [CONTRIBUTING.md](https://github.com/Dyl-M/liquipydia/blob/main/CONTRIBUTING.md) for guidelines.
 
 ## Security
 
-See [SECURITY.md](SECURITY.md) for reporting vulnerabilities.
+See [SECURITY.md](https://github.com/Dyl-M/liquipydia/blob/main/SECURITY.md) for reporting vulnerabilities.

--- a/_docs/ROADMAP.md
+++ b/_docs/ROADMAP.md
@@ -130,15 +130,30 @@ First PyPI release covering the full LPDB v3 surface.
 
 - [x] PyPI publish workflow (GitHub Actions, trusted publishing)
 - [x] `CHANGELOG.md` entry
-- [ ] GitHub Release with notes
+- [x] GitHub Release with notes
 
 ## Post-release
 
+- [x] Automatic semantic release (`python-semantic-release` v9, `.github/workflows/release.yml`)
+    - Parses Conventional Commit prefixes from squash-merge messages to determine bump type
+    - Bumps version in `pyproject.toml`, `__init__.py`, and `_client.py` automatically
+    - Commits, tags, and creates GitHub Release → triggers existing `publish.yml` → PyPI
+    - `CHANGELOG.md` remains manually maintained (not managed by PSR)
 - [ ] conda-forge package (submit recipe to `conda-forge/staged-recipes`, auto-rebuilds on PyPI releases)
 
 ## Future / Out of scope for v1
 
-- Async support (`AsyncLiquipediaClient` wrapping `httpx.AsyncClient`, async resource classes, `pytest-asyncio`)
+- Evaluate HTTP client dependency — `httpx` maintenance has stalled (last release: Nov 2024, no 0.28.2 despite merged
+  patches, issues/discussions disabled). The maintainer (Tom Christie / Encode) has a pattern of abandoning projects
+  (MkDocs, DRF, Starlette). Both Anthropic and OpenAI SDKs pin `httpx<1` anticipating breaking changes from a
+  potential 1.0 rewrite. Current usage in `_client.py` is minimal (sync `Client`, `Response`, `.get()`), making
+  migration straightforward. Candidates to watch:
+    - **httpxyz** — community fork of httpx (Mar 2026), drop-in replacement, stability-first philosophy, 2 maintainers.
+      Zero migration cost but very young project
+    - **niquests** — actively maintained `requests` successor with HTTP/2 and HTTP/3 support, good typing. Single
+      maintainer (bus factor). Would require rewriting `_client.py` against the `requests`-style API
+    - Decision should be made before async support work begins, as it heavily influences the async design
+- Async support (`AsyncLiquipediaClient` — depends on HTTP client evaluation above)
 - Query builder / fluent interface (`client.query("match").where(...).select(...)`) — evaluate after v1 based on usage
 - Response caching layer (local TTL cache)
 - CLI tool for quick queries

--- a/_tests/test_client.py
+++ b/_tests/test_client.py
@@ -152,6 +152,24 @@ class TestParseResponse:
         with _make_client() as client, pytest.raises(ApiError, match="unknown wiki"):
             client.get("player", {"wiki": "badwiki"})
 
+    @respx.mock
+    def test_malformed_json_raises_error(self) -> None:
+        """Verify malformed JSON response raises LiquipediaError."""
+        respx.get(f"{BASE_URL}player").mock(
+            return_value=httpx.Response(200, content=b"not-json", headers={"content-type": "text/plain"})
+        )
+
+        with _make_client() as client, pytest.raises(LiquipediaError, match="Failed to parse API response"):
+            client.get("player", {"wiki": "dota2"})
+
+    @respx.mock
+    def test_non_dict_json_raises_error(self) -> None:
+        """Verify non-dict JSON response raises LiquipediaError."""
+        respx.get(f"{BASE_URL}player").mock(return_value=httpx.Response(200, json=["unexpected", "list"]))
+
+        with _make_client() as client, pytest.raises(LiquipediaError, match="Unexpected API response format"):
+            client.get("player", {"wiki": "dota2"})
+
 
 # === HTTP Error Handling ===
 

--- a/_tests/test_init.py
+++ b/_tests/test_init.py
@@ -1,5 +1,8 @@
 """Tests for the liquipydia package initialization."""
 
+# Standard library
+import re
+
 from liquipydia import __author__, __version__
 
 
@@ -9,8 +12,8 @@ def test_version_is_string() -> None:
 
 
 def test_version_value() -> None:
-    """Verify that __version__ matches the expected value."""
-    assert __version__ == "0.1.0"
+    """Verify that __version__ follows semantic versioning format."""
+    assert re.fullmatch(r"\d+\.\d+\.\d+", __version__)
 
 
 def test_author() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,3 +134,28 @@ omit = ["_tests/*"]
 [tool.coverage.report]
 show_missing = true
 fail_under = 0
+
+# --- Semantic Release ---
+
+[tool.semantic_release]
+version_toml = ["pyproject.toml:project.version"]
+version_variables = [
+    "liquipydia/__init__.py:__version__",
+    "liquipydia/_client.py:_VERSION",
+]
+commit_message = "chore(release): v{version}"
+tag_format = "v{version}"
+build_command = false
+changelog = false
+
+[tool.semantic_release.branches.main]
+match = "main"
+
+[tool.semantic_release.remote]
+type = "github"
+token = { env = "GH_TOKEN" }
+
+[tool.semantic_release.commit_parser_options]
+allowed_tags = ["feat", "fix", "perf", "refactor", "docs", "style", "test", "build", "ci", "chore"]
+minor_tags = ["feat"]
+patch_tags = ["fix", "perf"]


### PR DESCRIPTION
## Summary

Add `python-semantic-release` v9 to automate version bumping, tagging, and GitHub Release creation on merge to `main`. Also fix broken relative links for PyPI rendering and improve test coverage for edge-case API responses.

## Changes

### Semantic release workflow (`.github/workflows/release.yml`, `pyproject.toml`)

* New `release.yml` workflow triggered on push to `main`
* Uses `python-semantic-release` v9.21.0 to parse Conventional Commit prefixes and determine bump type (`feat:` → minor, `fix:`/`perf:` → patch, `BREAKING CHANGE` → major)
* Automatically bumps version in all 3 locations (`pyproject.toml`, `__init__.py`, `_client.py`), commits with `chore(release): v{version}`, tags, and creates a GitHub Release
* Self-skipping: `if` guard prevents PSR's own `chore(release):` commits from re-triggering the workflow
* Changelog and build management are left to existing workflows (`publish.yml`, manual `CHANGELOG.md`)
* Uses existing `secrets.PAT` for pushing the version-bump commit and tag

### Test improvements (`_tests/test_init.py`, `_tests/test_client.py`)

* Replace hardcoded `== "0.1.0"` version assertion with a semver format regex check to prevent breakage on future bumps
* Add tests for malformed JSON and non-dict JSON API responses in `TestParseResponse`

### Documentation & links (`README.md`, `CONTRIBUTING.md`, `_docs/ROADMAP.md`)

* Replace relative file links with absolute GitHub URLs in `README.md` and `CONTRIBUTING.md` to fix broken links on PyPI
* Add PyPI version badge (auto-updates via shields.io)
* Reformat README title heading
* Update roadmap: mark v0.1.0 GitHub Release as complete, add semantic release as completed post-release item
* Expand "Future" section with HTTP client dependency evaluation

## Manual setup required

1. **Verify `secrets.PAT` scopes** — needs `repo` (classic) or `contents: write` + `metadata: read` (fine-grained)
2. **Update `main` branch ruleset** — add the PAT's actor to the bypass list so PSR can push the version-bump commit and tag directly

## Validation steps before merge

- [x] Lint & Test CI OK (no regression)
- [x] DeepSource health check OK (no regression)
- [x] Human review completed (post-changes made by DeepSource or automated tools)