### PR TITLE
Documentation overhaul, theme-aware favicon, and looser runtime dependency ranges

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -59,8 +59,12 @@ jobs:
         run: uv run mypy liquipydia
 
   test:
-    name: Tests
+    name: Tests (${{ matrix.resolution }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        resolution: [ highest, lowest-direct ]
 
     steps:
       - name: Checkout repository
@@ -75,20 +79,26 @@ jobs:
         run: uv python install 3.12
 
       - name: Install dependencies
-        run: uv sync --group test
+        run: uv sync --group test --resolution ${{ matrix.resolution }}
 
-      - name: Run tests with coverage
+      - name: Run unit tests with coverage
+        run: uv run coverage run -m pytest -m "not integration"
+
+      - name: Run integration tests
+        if: matrix.resolution == 'highest'
         env:
           LPDB_API_KEY: ${{ secrets.LPDB_API_KEY }}
-        run: uv run coverage run -m pytest
+        run: uv run coverage run -a -m pytest -m integration
 
       - name: Coverage report
         run: uv run coverage report
 
       - name: Generate coverage XML
+        if: matrix.resolution == 'highest'
         run: uv run coverage xml
 
       - name: Report coverage to DeepSource
+        if: matrix.resolution == 'highest'
         uses: deepsourcelabs/test-coverage-action@master
         with:
           key: python

--- a/.gitignore
+++ b/.gitignore
@@ -208,6 +208,7 @@ __marimo__/
 
 # Private ressources
 .claude/
+.remember/
 .tokens/
 _drafts/
 CLAUDE.md

--- a/_docs/sphinx/_static/database-search-dark.svg
+++ b/_docs/sphinx/_static/database-search-dark.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#5BA3D9" stroke-width="2"
+     stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-database-search-icon lucide-database-search">
+    <path d="M21 11.693V5"/>
+    <path d="m22 22-1.875-1.875"/>
+    <path d="M3 12a9 3 0 0 0 8.697 2.998"/>
+    <path d="M3 5v14a9 3 0 0 0 9.28 2.999"/>
+    <circle cx="18" cy="18" r="3"/>
+    <ellipse cx="12" cy="5" rx="9" ry="3"/>
+</svg>

--- a/_docs/sphinx/_static/database-search.svg
+++ b/_docs/sphinx/_static/database-search.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#072B4B" stroke-width="2"
+     stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-database-search-icon lucide-database-search">
+    <path d="M21 11.693V5"/>
+    <path d="m22 22-1.875-1.875"/>
+    <path d="M3 12a9 3 0 0 0 8.697 2.998"/>
+    <path d="M3 5v14a9 3 0 0 0 9.28 2.999"/>
+    <circle cx="18" cy="18" r="3"/>
+    <ellipse cx="12" cy="5" rx="9" ry="3"/>
+</svg>

--- a/_docs/sphinx/_templates/page.html
+++ b/_docs/sphinx/_templates/page.html
@@ -1,5 +1,11 @@
 {% extends "!page.html" %}
 
+{% block extrahead %}
+{{ super() }}
+<link rel="icon" type="image/svg+xml" href="{{ pathto('_static/database-search-dark.svg', 1) }}"
+      media="(prefers-color-scheme: dark)">
+{% endblock %}
+
 {% block footer %}
 {{ super() | replace("Dylan Monfret @Dyl-M", '<a href="https://github.com/Dyl-M">Dylan Monfret @Dyl-M</a>') }}
 {% endblock %}

--- a/_docs/sphinx/api/client.rst
+++ b/_docs/sphinx/api/client.rst
@@ -3,17 +3,22 @@ Client
 
 The main entry point for interacting with the Liquipedia API.
 
-After construction, access data through resource attributes (e.g. ``client.players``,
-``client.matches``). See :doc:`resources` for the full list.
+A ``LiquipediaClient`` instance owns a single ``httpx`` session and exposes one resource attribute
+per LPDB v3 data type (e.g. ``client.players``, ``client.matches``). See :doc:`resources` for the
+full list and per-resource details.
+
+Use the client as a context manager — the ``with`` block guarantees the HTTP session is closed
+on exit, including when exceptions propagate.
 
 .. autoclass:: liquipydia.LiquipediaClient
-   :members: __init__, close, __enter__, __exit__
+   :members: __init__, close
 
-Low-level methods
------------------
+Direct HTTP access
+------------------
 
-These methods are used internally by resource classes. You typically don't need to call them
-directly — use the resource ``list()`` and ``paginate()`` methods instead.
+The methods below are public and resource classes call them internally. You only need them when
+hitting an endpoint that the resource layer does not yet model, or when implementing your own
+``Resource`` subclass.
 
 .. automethod:: liquipydia.LiquipediaClient.get
    :no-index:

--- a/_docs/sphinx/api/exceptions.rst
+++ b/_docs/sphinx/api/exceptions.rst
@@ -1,20 +1,38 @@
 Exceptions
 ==========
 
-All exceptions inherit from :class:`~liquipydia.LiquipediaError`, so you can catch it as a
-base class for any library error.
+All exceptions raised by liquipydia inherit from :class:`~liquipydia.LiquipediaError`. Catch the
+base class to handle every library failure with a single ``except``, or catch specific subclasses
+when you want to react differently per failure mode.
 
-.. autoclass:: liquipydia.LiquipediaError
+Hierarchy
+---------
+
+.. code-block:: text
+
+   LiquipediaError              # base — catch this for any library error
+   ├── AuthError                # HTTP 403: invalid or missing API key
+   ├── NotFoundError            # HTTP 404: requested data does not exist
+   ├── RateLimitError           # HTTP 429: retries exhausted (carries retry_after)
+   └── ApiError                 # API responded 2xx but the body contains an error array
+
+Other transport-level failures (non-2xx responses without a dedicated subclass, malformed JSON,
+unexpected response shapes) are raised as the bare :class:`~liquipydia.LiquipediaError`.
+
+Reference
+---------
+
+.. autoexception:: liquipydia.LiquipediaError
    :members:
 
-.. autoclass:: liquipydia.AuthError
+.. autoexception:: liquipydia.AuthError
    :members:
 
-.. autoclass:: liquipydia.NotFoundError
+.. autoexception:: liquipydia.NotFoundError
    :members:
 
-.. autoclass:: liquipydia.RateLimitError
+.. autoexception:: liquipydia.RateLimitError
    :members:
 
-.. autoclass:: liquipydia.ApiError
+.. autoexception:: liquipydia.ApiError
    :members:

--- a/_docs/sphinx/api/models.rst
+++ b/_docs/sphinx/api/models.rst
@@ -3,101 +3,91 @@
 Models
 ======
 
-Pydantic models for typed access to API response records. Use ``Model.model_validate(record)``
-on dicts from :class:`~liquipydia.ApiResponse`.
+Pydantic models for typed access to API response records. The client returns raw dicts inside
+:class:`~liquipydia.ApiResponse`; convert each one with ``Model.model_validate(record)``:
 
-All fields are optional (``type | None = None``) for forward compatibility. Unknown API fields
-are preserved via ``extra="allow"``.
+.. code-block:: python
+
+   from liquipydia import LiquipediaClient, Player
+
+   with LiquipediaClient("my-app") as client:
+       response = client.players.list("dota2", limit=5)
+       players = [Player.model_validate(record) for record in response.result]
+
+Conventions
+-----------
+
+- **All fields are optional** (``type | None = None``). LPDB endpoints can omit fields without
+  notice, so models never raise on missing data.
+- **Unknown fields are preserved** via ``ConfigDict(extra="allow")``. New API fields are
+  accessible on the validated model even before this library is updated.
+- **Models are standalone.** They don't reference the client or each other and can be reused for
+  any dict that follows the LPDB schema.
 
 Type aliases
 ------------
 
-These handle LPDB API quirks automatically:
+Three reusable field types handle LPDB's quirky null-encoding so consumers see clean
+``None`` / ``date`` / ``datetime`` / ``dict`` values:
 
-- **NullableDate** — converts null sentinels (``"0000-01-01"``, ``""``) to ``None``
-- **NullableDatetime** — same for datetime fields (``"0000-01-01 00:00:00"``)
-- **LpdbDict** — converts empty API lists (``[]``) to ``None`` for dict-like fields
+.. autodata:: liquipydia._models.NullableDate
+   :no-value:
 
-Base classes
-------------
+.. autodata:: liquipydia._models.NullableDatetime
+   :no-value:
 
-Most models inherit from ``_LpdbModel``, which provides common fields shared across standard
-endpoints. Team template models use ``_TeamTemplateBase`` instead (different field set).
+.. autodata:: liquipydia._models.LpdbDict
+   :no-value:
+
+A handful of fields (e.g. ``stream`` on :class:`~liquipydia.Match`, ``earningsbyyear`` on
+:class:`~liquipydia.Player`) legitimately vary between dict and list shapes. Those use an
+explicit ``dict[str, Any] | list[Any] | None`` union rather than ``LpdbDict``.
+
+Internal base classes
+---------------------
+
+The classes below are not part of the public API (they are prefixed with ``_``). They are
+documented here only to make field inheritance visible — refer to the concrete model classes for
+day-to-day use.
 
 .. autoclass:: liquipydia._models._LpdbModel
-   :members:
-   :inherited-members: BaseModel
 
 .. autoclass:: liquipydia._models._TeamTemplateBase
-   :members:
-   :inherited-members: BaseModel
 
 Standard models
 ---------------
 
 .. autoclass:: liquipydia.Broadcaster
-   :members:
-   :inherited-members: BaseModel
 
 .. autoclass:: liquipydia.Company
-   :members:
-   :inherited-members: BaseModel
 
 .. autoclass:: liquipydia.Datapoint
-   :members:
-   :inherited-members: BaseModel
 
 .. autoclass:: liquipydia.ExternalMediaLink
-   :members:
-   :inherited-members: BaseModel
 
 .. autoclass:: liquipydia.Match
-   :members:
-   :inherited-members: BaseModel
 
 .. autoclass:: liquipydia.Placement
-   :members:
-   :inherited-members: BaseModel
 
 .. autoclass:: liquipydia.Player
-   :members:
-   :inherited-members: BaseModel
 
 .. autoclass:: liquipydia.Series
-   :members:
-   :inherited-members: BaseModel
 
 .. autoclass:: liquipydia.SquadPlayer
-   :members:
-   :inherited-members: BaseModel
 
 .. autoclass:: liquipydia.StandingsEntry
-   :members:
-   :inherited-members: BaseModel
 
 .. autoclass:: liquipydia.StandingsTable
-   :members:
-   :inherited-members: BaseModel
 
 .. autoclass:: liquipydia.Team
-   :members:
-   :inherited-members: BaseModel
 
 .. autoclass:: liquipydia.Tournament
-   :members:
-   :inherited-members: BaseModel
 
 .. autoclass:: liquipydia.Transfer
-   :members:
-   :inherited-members: BaseModel
 
 Team template models
 --------------------
 
 .. autoclass:: liquipydia.TeamTemplate
-   :members:
-   :inherited-members: BaseModel
 
 .. autoclass:: liquipydia.TeamTemplateList
-   :members:
-   :inherited-members: BaseModel

--- a/_docs/sphinx/api/resources.rst
+++ b/_docs/sphinx/api/resources.rst
@@ -1,11 +1,21 @@
 Resources
 =========
 
-Resource classes wrap individual LPDB v3 endpoints. Each resource is accessible as an attribute on
-:class:`~liquipydia.LiquipediaClient`.
+Resource classes wrap individual LPDB v3 endpoints. Each resource is reachable as an attribute on
+:class:`~liquipydia.LiquipediaClient`. The resource layer adds three things on top of the raw
+HTTP API:
+
+- **Keyword filters** — kwargs like ``nationality="Denmark"`` are turned into
+  ``[[nationality::Denmark]]`` and AND-joined with any explicit ``conditions`` string.
+- **Filter-key validation** — keys that don't match the resource's Pydantic model raise
+  ``ValueError`` before a request goes out.
+- **Pagination** — ``paginate()`` yields individual records, transparently fetching successive
+  pages.
 
 Base class
 ----------
+
+All standard endpoints share the same surface, defined on :class:`~liquipydia.Resource`:
 
 .. autoclass:: liquipydia.Resource
    :members: list, paginate
@@ -13,49 +23,78 @@ Base class
 Standard resources
 ------------------
 
-These resources inherit ``list()`` and ``paginate()`` from ``Resource`` without modifications.
+These 13 resources inherit ``list()`` and ``paginate()`` from :class:`~liquipydia.Resource`
+unchanged. They differ only in their endpoint path and the model used for filter-key validation:
 
-.. autoclass:: liquipydia.BroadcastersResource
+.. list-table::
+   :header-rows: 1
+   :widths: 35 25 25
 
-.. autoclass:: liquipydia.CompaniesResource
-
-.. autoclass:: liquipydia.DatapointsResource
-
-.. autoclass:: liquipydia.ExternalMediaLinksResource
-
-.. autoclass:: liquipydia.PlacementsResource
-
-.. autoclass:: liquipydia.PlayersResource
-
-.. autoclass:: liquipydia.SeriesResource
-
-.. autoclass:: liquipydia.SquadPlayersResource
-
-.. autoclass:: liquipydia.StandingsEntriesResource
-
-.. autoclass:: liquipydia.StandingsTablesResource
-
-.. autoclass:: liquipydia.TeamsResource
-
-.. autoclass:: liquipydia.TournamentsResource
-
-.. autoclass:: liquipydia.TransfersResource
+   * - Class
+     - Endpoint
+     - Model
+   * - :class:`~liquipydia.BroadcastersResource`
+     - ``/broadcasters``
+     - :class:`~liquipydia.Broadcaster`
+   * - :class:`~liquipydia.CompaniesResource`
+     - ``/company``
+     - :class:`~liquipydia.Company`
+   * - :class:`~liquipydia.DatapointsResource`
+     - ``/datapoint``
+     - :class:`~liquipydia.Datapoint`
+   * - :class:`~liquipydia.ExternalMediaLinksResource`
+     - ``/externalmedialink``
+     - :class:`~liquipydia.ExternalMediaLink`
+   * - :class:`~liquipydia.PlacementsResource`
+     - ``/placement``
+     - :class:`~liquipydia.Placement`
+   * - :class:`~liquipydia.PlayersResource`
+     - ``/player``
+     - :class:`~liquipydia.Player`
+   * - :class:`~liquipydia.SeriesResource`
+     - ``/series``
+     - :class:`~liquipydia.Series`
+   * - :class:`~liquipydia.SquadPlayersResource`
+     - ``/squadplayer``
+     - :class:`~liquipydia.SquadPlayer`
+   * - :class:`~liquipydia.StandingsEntriesResource`
+     - ``/standingsentry``
+     - :class:`~liquipydia.StandingsEntry`
+   * - :class:`~liquipydia.StandingsTablesResource`
+     - ``/standingstable``
+     - :class:`~liquipydia.StandingsTable`
+   * - :class:`~liquipydia.TeamsResource`
+     - ``/team``
+     - :class:`~liquipydia.Team`
+   * - :class:`~liquipydia.TournamentsResource`
+     - ``/tournament``
+     - :class:`~liquipydia.Tournament`
+   * - :class:`~liquipydia.TransfersResource`
+     - ``/transfer``
+     - :class:`~liquipydia.Transfer`
 
 Specialized resources
 ---------------------
 
+Three resources need their own entry, either because of an extra parameter or a different method
+signature.
+
 MatchResource
 ^^^^^^^^^^^^^
 
-Inherits ``list()`` and ``paginate()`` from ``Resource``. The ``rawstreams`` and ``streamurls``
-parameters are only meaningful on this endpoint.
+Inherits ``list()`` and ``paginate()`` from :class:`~liquipydia.Resource`. The ``rawstreams`` and
+``streamurls`` keyword arguments accepted by the base class are only meaningful on this endpoint;
+on any other resource the API ignores them.
 
 .. autoclass:: liquipydia.MatchResource
 
 TeamTemplateResource
 ^^^^^^^^^^^^^^^^^^^^
 
-Different API signature — uses ``get()`` instead of ``list()``.
+Single-template lookup. Uses ``get(wiki, template, date=...)`` — ``conditions``, ``limit``,
+``offset``, ``order`` and multi-wiki are not supported. The optional ``date`` parameter returns
+the template state at that historical date (useful for rendering era-correct logos on archived
+tournament pages).
 
 .. autoclass:: liquipydia.TeamTemplateResource
    :members: get
@@ -63,7 +102,17 @@ Different API signature — uses ``get()`` instead of ``list()``.
 TeamTemplateListResource
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-Different API signature — uses ``pagination`` parameter instead of ``limit``/``offset``.
+Bulk template listing. Uses ``list(wiki, pagination=N)`` — page-based navigation, no
+``limit``/``offset`` and no multi-wiki. Some result rows can be ``None`` and must be filtered
+before validation:
+
+.. code-block:: python
+
+   response = client.team_template_list.list("rocketleague")
+   for record in response.result:
+       if record is None:
+           continue
+       template = TeamTemplateList.model_validate(record)
 
 .. autoclass:: liquipydia.TeamTemplateListResource
    :members: list

--- a/_docs/sphinx/api/response.rst
+++ b/_docs/sphinx/api/response.rst
@@ -1,4 +1,23 @@
 Response
 ========
 
+Every successful API call returns an :class:`~liquipydia.ApiResponse`. It is an immutable
+dataclass holding the raw response payload — the resource layer leaves parsing into Pydantic
+models to the caller, so you can opt in or out per query.
+
+.. code-block:: python
+
+   from liquipydia import LiquipediaClient, Player
+
+   with LiquipediaClient("my-app") as client:
+       response = client.players.list("dota2", limit=5)
+
+       # response.result is a list of dicts; convert to typed models when you need them
+       players = [Player.model_validate(record) for record in response.result]
+
+       # response.warnings carries non-fatal API warnings (always a list, possibly empty)
+       for warning in response.warnings:
+           print(f"[liquipedia] {warning}")
+
 .. autoclass:: liquipydia.ApiResponse
+   :no-members:

--- a/_docs/sphinx/conf.py
+++ b/_docs/sphinx/conf.py
@@ -58,6 +58,8 @@ intersphinx_mapping = {
 
 html_theme = "furo"
 html_title = "liquipydia"
+html_static_path = ["_static"]
+html_favicon = "_static/database-search.svg"
 
 html_theme_options = {
     "source_repository": "https://github.com/Dyl-M/liquipydia",

--- a/_docs/sphinx/examples.md
+++ b/_docs/sphinx/examples.md
@@ -1,68 +1,94 @@
 # Examples
 
-All examples assume you have a `LiquipediaClient` instance:
+All examples below use the recommended context-manager form. The `with` statement guarantees the
+underlying HTTP session is closed even if an exception is raised:
 
 ```python
 from liquipydia import LiquipediaClient
 
-client = LiquipediaClient("my-app", api_key="your-api-key")
+with LiquipediaClient("my-app", api_key="your-api-key") as client:
+    ...  # all calls go inside this block
 ```
 
-```{tip}
-Use the client as a context manager to ensure the HTTP session is properly closed:
-
-    with LiquipediaClient("my-app", api_key="your-api-key") as client:
-        ...
-```
+For brevity, the `with` block is omitted in the snippets below — assume each example runs inside one.
 
 ## Standard resources
 
-Most resources share the same `list()` and `paginate()` interface. Here are some examples using
-`players`, but the same pattern applies to `broadcasters`, `companies`, `datapoints`,
-`external_media_links`, `placements`, `series`, `squad_players`, `standings_entries`,
-`standings_tables`, `teams`, `tournaments`, and `transfers`.
+13 of the 16 resources share the same `list()` and `paginate()` interface: `broadcasters`,
+`companies`, `datapoints`, `external_media_links`, `matches`, `placements`, `players`, `series`,
+`squad_players`, `standings_entries`, `standings_tables`, `teams`, `tournaments`, `transfers`.
+
+The examples below use `players` and `tournaments`, but the pattern is identical for the others.
 
 ### Basic query
 
 ```python
 from liquipydia import Player
 
-response = client.players.list("dota2", limit=10)
+response = client.players.list("rocketleague", limit=5, order="earnings DESC")
 
 for record in response.result:
     player = Player.model_validate(record)
-    print(player.name, player.nationality)
+    print(player.id, player.nationality, player.earnings)
 ```
 
-```text
-Miracle- Jordan
-SumaiL Pakistan
-...
-```
+The default `limit` is 50. Without an `order`, the API returns records in its own internal order —
+add an explicit `order` whenever you care about which records come first.
 
-### LPDB conditions
+### Conditions syntax
+
+LPDB conditions use double-bracket delimiters with these operators:
+
+| Syntax              | Meaning      |
+|---------------------|--------------|
+| `[[col::value]]`    | Equals       |
+| `[[col::!value]]`   | Not equals   |
+| `[[col::<value]]`   | Less than    |
+| `[[col::>value]]`   | Greater than |
+
+Combine with `AND` / `OR` and group with parentheses:
 
 ```python
-response = client.players.list(
-    "counterstrike",
-    conditions="[[nationality::Denmark]] AND [[status::Active]]",
+response = client.tournaments.list(
+    "dota2",
+    conditions="[[liquipediatier::1]] AND ([[type::Online]] OR [[type::Offline]])",
     limit=20,
 )
 ```
 
+JSON subkeys are accessed with an underscore (e.g. `[[extradata_key::value]]`). Date columns
+support `YEAR()`, `MONTH()`, `DAY()`, `HOUR()`, `MINUTE()`, `SECOND()` via virtual fields like
+`birthdate_year`.
+
 ### Keyword filters
 
-Instead of writing raw LPDB condition strings, use keyword arguments:
+Instead of writing condition strings by hand, pass keyword arguments — each becomes one
+`[[key::value]]` term, AND-joined automatically:
 
 ```python
-# Simple equality
+# Equivalent to conditions="[[pagename::Zen]]"
 response = client.players.list("rocketleague", pagename="Zen")
-
-# Operator prefixes: > (greater), < (less), ! (not)
-response = client.tournaments.list("dota2", liquipediatier="1", prizepool=">100000")
 ```
 
-Keyword filters can be combined with explicit `conditions`:
+The same operator prefixes from the conditions syntax also work in values:
+
+```python
+# >, <, ! are passed through verbatim into the condition string
+response = client.tournaments.list(
+    "dota2",
+    liquipediatier="1",         # equals
+    prizepool=">100000",        # greater than
+    type="!Online",             # not equals
+)
+```
+
+```{note}
+Keyword filter keys are validated against the resource's Pydantic model fields and raise
+`ValueError` if unknown. Raw `conditions` strings are *not* validated — the API silently returns
+no results for unknown column names.
+```
+
+Keyword filters and an explicit `conditions` string can be combined; they are AND-joined:
 
 ```python
 response = client.players.list(
@@ -74,63 +100,99 @@ response = client.players.list(
 
 ### Selecting fields
 
-Use the `query` parameter to return only specific fields:
+Use `query` to return only specific fields. This reduces payload size on large queries:
 
 ```python
-response = client.players.list("dota2", query="pagename,name,nationality", limit=5)
+response = client.players.list(
+    "dota2",
+    query="pagename,id,nationality",
+    limit=5,
+)
+for record in response.result:
+    print(record["pagename"], record.get("nationality"))
+```
+
+```{tip}
+`query` also supports aggregate functions (`sum::prizemoney`, `count::id`) and date extractors
+(`year::birthdate`). The result field name becomes `sum_prizemoney`, `year_birthdate`, etc.
 ```
 
 ### Ordering and grouping
 
+`order` is SQL-style; use `ASC` / `DESC` and chain with commas:
+
 ```python
-response = client.tournaments.list("dota2", order="startdate DESC", limit=10)
+response = client.tournaments.list(
+    "dota2",
+    order="startdate DESC, prizepool DESC",
+    limit=10,
+)
+```
+
+`groupby` follows the same syntax and is useful with aggregate `query` functions:
+
+```python
+response = client.placements.list(
+    "dota2",
+    query="sum::prizemoney",
+    groupby="opponentname ASC",
+    limit=20,
+)
 ```
 
 ### Multi-wiki queries
 
-Pipe-separate wiki names to query across multiple games:
+Pipe-separate wiki names to query across multiple games in a single request:
 
 ```python
-response = client.players.list("dota2|counterstrike", limit=10)
+response = client.players.list("dota2|counterstrike", nationality="Denmark", limit=20)
 ```
+
+Single-wiki endpoints (`team_templates`, `team_template_list`) don't support multi-wiki.
 
 ## Pagination
 
-The `paginate()` method handles offset management automatically, yielding individual records:
+`paginate()` handles offset management automatically and yields individual record dicts:
 
 ```python
-from liquipydia import Match
+from liquipydia import Tournament
 
-# Get up to 500 matches, 100 per page
-for record in client.matches.paginate("counterstrike", page_size=100, max_results=500):
-    match = Match.model_validate(record)
-    print(match.match2id, match.date)
+# Iterate 200 Dota 2 tournaments, 50 per request
+tournaments = client.tournaments.paginate(
+    "dota2",
+    order="startdate DESC",
+    page_size=50,
+    max_results=200,
+)
+for record in tournaments:
+    tournament = Tournament.model_validate(record)
+    print(tournament.name, tournament.startdate)
 ```
 
-```text
-0042_R01-M001 2025-06-15 14:00:00
-0042_R01-M002 2025-06-15 15:30:00
-...
-```
-
-Without `max_results`, pagination continues until no more results are returned:
+Without `max_results`, pagination continues until a page returns fewer rows than `page_size`:
 
 ```python
-# Iterate through ALL players (use with caution)
-for record in client.players.paginate("rocketleague", page_size=200):
+# Walk every Active Danish CS player — bounded by a filter, not a hard cap
+for record in client.players.paginate(
+    "counterstrike",
+    nationality="Denmark",
+    status="Active",
+    page_size=100,
+):
     player = Player.model_validate(record)
-    print(player.name)
+    print(player.id)
 ```
 
-```text
-Zen
-Vatira
-...
+```{warning}
+Always pair an unbounded `paginate()` with restrictive filters or `max_results`. Iterating the
+full population of a resource on a large wiki can take many minutes and burn through rate-limit
+budget.
 ```
 
 ## Matches (stream data)
 
-The match resource supports two extra parameters for stream data:
+The `/match` endpoint accepts two extra parameters that ask the API to include broadcaster stream
+metadata in each match record:
 
 ```python
 from liquipydia import Match
@@ -139,43 +201,41 @@ response = client.matches.list(
     "rocketleague",
     rawstreams=True,
     streamurls=True,
+    order="date DESC",
     limit=5,
 )
-
 for record in response.result:
     match = Match.model_validate(record)
-    print(match.match2id, match.stream)
+    if match.stream:
+        print(match.match2id, match.date, list(match.stream))
 ```
 
-```text
-0001_R01-M001 {'twitch': 'rocketleague', 'youtube': '...'}
-0001_R01-M002 {'twitch': 'rocketleague'}
-...
-```
-
-These parameters also work with `paginate()`:
+Both parameters also work with `paginate()`:
 
 ```python
-for record in client.matches.paginate("dota2", rawstreams=True, max_results=50):
+for record in client.matches.paginate(
+    "dota2",
+    rawstreams=True,
+    streamurls=True,
+    order="date DESC",
+    max_results=50,
+):
     match = Match.model_validate(record)
-    print(match.match2id, match.stream)
-```
-
-```text
-0001_R01-M001 {'twitch': 'daboross', 'youtube': '...'}
-...
 ```
 
 ```{note}
-`rawstreams` and `streamurls` are accepted on all resources but only meaningful for the `/match`
-endpoint. On other resources, they are silently ignored.
+`rawstreams` and `streamurls` are accepted on every resource for API uniformity but only
+meaningful on `/match`. On other endpoints they are silently ignored by the API. The library
+omits both parameters from the request when they are `False` (the default).
 ```
 
 ## Team templates
 
-Team template endpoints have a different API signature from standard resources.
+Team-template endpoints have a different signature — neither `conditions` nor `limit`/`offset`
+applies. Both endpoints occasionally return `None` entries mixed into `response.result`, so always
+filter before validating.
 
-### Single lookup
+### Single template lookup
 
 ```python
 from liquipydia import TeamTemplate
@@ -183,18 +243,17 @@ from liquipydia import TeamTemplate
 response = client.team_templates.get("dota2", "teamliquid")
 
 for record in response.result:
-    if record is not None:
-        template = TeamTemplate.model_validate(record)
-        print(template.name, template.shortname)
+    if record is None:
+        continue
+    template = TeamTemplate.model_validate(record)
+    print(template.template, template.name, template.shortname)
 ```
 
-```text
-Team Liquid TL
-```
-
-Use the `date` parameter for historical logos:
+The optional `date` parameter returns the template state at that point in time — useful when
+rendering historical tournament pages with the era-correct logo:
 
 ```python
+# Team Liquid's logo as it stood on 2020-01-01
 response = client.team_templates.get("dota2", "teamliquid", date="2020-01-01")
 ```
 
@@ -206,25 +265,39 @@ from liquipydia import TeamTemplateList
 response = client.team_template_list.list("rocketleague")
 
 for record in response.result:
-    if record is not None:
-        template = TeamTemplateList.model_validate(record)
-        print(template.template, template.name)
+    if record is None:
+        continue
+    template = TeamTemplateList.model_validate(record)
+    print(template.template, template.name)
 ```
 
-```text
-teamliquid Team Liquid
-g2esports G2 Esports
-...
-```
-
-Use `pagination` for page-based navigation:
+This endpoint uses page-based navigation via the `pagination` parameter (no `limit`/`offset`):
 
 ```python
 # Get page 2
 response = client.team_template_list.list("rocketleague", pagination=2)
 ```
 
+## Inspecting warnings
+
+`ApiResponse` carries any non-fatal warnings the API emitted alongside the result. They never
+raise — check the field if you want to surface them:
+
+```python
+response = client.players.list("dota2", limit=5)
+
+if response.warnings:
+    for warning in response.warnings:
+        print(f"[liquipedia] {warning}")
+
+for record in response.result:
+    ...
+```
+
 ## Error handling
+
+All exceptions inherit from `LiquipediaError`, so catching it alone covers everything. Catch
+specific subclasses when you want to react differently per failure mode:
 
 ```python
 from liquipydia import (
@@ -243,10 +316,17 @@ with LiquipediaClient("my-app", api_key="your-api-key") as client:
         print("Invalid or missing API key")
     except NotFoundError:
         print("Requested data does not exist")
-    except RateLimitError as e:
-        print(f"Rate limited — retry after {e.retry_after}s")
-    except ApiError as e:
-        print(f"API error: {e.message}")
-    except LiquipediaError as e:
-        print(f"Unexpected error: {e.message}")
+    except RateLimitError as exc:
+        if exc.retry_after is not None:
+            print(f"Rate limited — retry after {exc.retry_after}s")
+        else:
+            print("Rate limited — no Retry-After hint provided")
+    except ApiError as exc:
+        print(f"API returned an error: {exc.message}")
+    except LiquipediaError as exc:
+        print(f"Other library error: {exc.message}")
 ```
+
+The client retries `429` responses with exponential backoff up to `max_retries` times before
+raising `RateLimitError`. If you need to handle rate limits explicitly without retries, set
+`max_retries=0` on construction.

--- a/_docs/sphinx/getting-started.md
+++ b/_docs/sphinx/getting-started.md
@@ -2,11 +2,11 @@
 
 ## API access
 
-Using this library requires an API key from Liquipedia. Access is **not self-service** — you must request it through
-their [contact form](https://liquipedia.net/api).
+Using this library requires an API key from Liquipedia. Access is **not self-service** — you must
+request it through their [contact form](https://liquipedia.net/api).
 
-Free access is available for **educational**, **non-commercial open-source**, and **community** projects.
-Paid plans (Basic, Premium, Enterprise) are available for commercial use.
+Free access is available for **educational**, **non-commercial open-source**, and **community**
+projects. Paid plans (Basic, Premium, Enterprise) are available for commercial use.
 
 ## Installation
 
@@ -42,60 +42,81 @@ from liquipydia import LiquipediaClient
 # Option 1: pass directly
 client = LiquipediaClient("my-app", api_key="your-api-key")
 
-# Option 2: environment variable
-# export LIQUIPEDIA_API_KEY=your-api-key
+# Option 2: read from LIQUIPEDIA_API_KEY env var
 client = LiquipediaClient("my-app")
 ```
+
+The first positional argument is the **application name**. It is included in the `User-Agent`
+header of every request, alongside the library version, so Liquipedia operators can identify
+traffic from your project.
 
 ## Quickstart
 
 ```python
-from liquipydia import LiquipediaClient, Player, Match
+from liquipydia import LiquipediaClient, Player, Tournament
 
 with LiquipediaClient("my-app", api_key="your-api-key") as client:
-    # Query players from a specific wiki
-    response = client.players.list("dota2", pagename="Miracle-")
+    # Single query: top earners on the Dota 2 wiki
+    response = client.players.list("dota2", order="earnings DESC", limit=5)
     for record in response.result:
         player = Player.model_validate(record)
-        print(player.name, player.nationality, player.birthdate)
+        print(player.id, player.nationality, player.earnings)
 
-    # Automatic pagination across multiple pages
-    for record in client.matches.paginate("counterstrike", page_size=100, max_results=500):
-        match = Match.model_validate(record)
-        print(match.match2id, match.date, match.winner)
+    # Automatic pagination — iterate Tier-1 Dota 2 tournaments page by page
+    for record in client.tournaments.paginate(
+        "dota2",
+        liquipediatier="1",
+        order="startdate DESC",
+        page_size=50,
+        max_results=200,
+    ):
+        tournament = Tournament.model_validate(record)
+        print(tournament.name, tournament.startdate)
 
-    # Keyword filters — no need to write raw LPDB conditions
-    response = client.players.list("rocketleague", pagename="Zen")
-
-    # Team template lookup
+    # Single team-template lookup (different signature — uses get())
     response = client.team_templates.get("dota2", "teamliquid")
 ```
 
-```text
-Miracle- Jordan 1997-06-20
-0042_R01-M001 2025-06-15 14:00:00 1
-...
+See {doc}`examples` for queries with conditions, multi-wiki, stream metadata, error handling, and
+more.
+
+## Tuning
+
+`LiquipediaClient` accepts a few keyword arguments to tune HTTP behaviour:
+
+```python
+client = LiquipediaClient(
+    "my-app",
+    api_key="your-api-key",
+    timeout=30.0,             # per-request timeout (seconds)
+    max_retries=3,            # retries on HTTP 429 before raising RateLimitError
+    retry_backoff_factor=1.0, # base for exponential backoff between retries
+)
 ```
+
+The retry loop honours the API's `Retry-After` header when present and otherwise uses exponential
+backoff capped at 60 seconds. Set `max_retries=0` to disable automatic retrying and let your code
+handle `RateLimitError` directly.
 
 ## Available resources
 
 All 16 LPDB v3 data types are accessible as client attributes:
 
-| Attribute                     | Endpoint             | Notes                             |
-|-------------------------------|----------------------|-----------------------------------|
-| `client.broadcasters`         | `/broadcasters`      |                                   |
-| `client.companies`            | `/company`           |                                   |
-| `client.datapoints`           | `/datapoint`         |                                   |
-| `client.external_media_links` | `/externalmedialink` |                                   |
-| `client.matches`              | `/match`             | Extra: `rawstreams`, `streamurls` |
-| `client.placements`           | `/placement`         |                                   |
-| `client.players`              | `/player`            |                                   |
-| `client.series`               | `/series`            |                                   |
-| `client.squad_players`        | `/squadplayer`       |                                   |
-| `client.standings_entries`    | `/standingsentry`    |                                   |
-| `client.standings_tables`     | `/standingstable`    |                                   |
-| `client.teams`                | `/team`              |                                   |
-| `client.tournaments`          | `/tournament`        |                                   |
-| `client.transfers`            | `/transfer`          |                                   |
-| `client.team_templates`       | `/teamtemplate`      | Uses `get()` instead of `list()`  |
-| `client.team_template_list`   | `/teamtemplatelist`  | Different params (`pagination`)   |
+| Attribute                     | Endpoint             | Notes                                         |
+|-------------------------------|----------------------|-----------------------------------------------|
+| `client.broadcasters`         | `/broadcasters`      |                                               |
+| `client.companies`            | `/company`           |                                               |
+| `client.datapoints`           | `/datapoint`         |                                               |
+| `client.external_media_links` | `/externalmedialink` |                                               |
+| `client.matches`              | `/match`             | Extra: `rawstreams`, `streamurls`             |
+| `client.placements`           | `/placement`         |                                               |
+| `client.players`              | `/player`            |                                               |
+| `client.series`               | `/series`            |                                               |
+| `client.squad_players`        | `/squadplayer`       |                                               |
+| `client.standings_entries`    | `/standingsentry`    |                                               |
+| `client.standings_tables`     | `/standingstable`    |                                               |
+| `client.teams`                | `/team`              |                                               |
+| `client.tournaments`          | `/tournament`        |                                               |
+| `client.transfers`            | `/transfer`          |                                               |
+| `client.team_templates`       | `/teamtemplate`      | `get(wiki, template, date=...)` — single wiki |
+| `client.team_template_list`   | `/teamtemplatelist`  | Page-based via `pagination=N` — single wiki   |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,8 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "httpx==0.28.1",
-    "pydantic==2.13.3",
+    "httpx>=0.28,<1",
+    "pydantic>=2.13,<3",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary

Rework the Sphinx user guide and API reference to match the actual public surface of `liquipydia`, ship a theme-aware favicon for the documentation site, and switch runtime dependencies (`httpx`, `pydantic`) from exact pins to compatible ranges so library consumers can resolve them alongside their own deps. CI now exercises both `highest` and `lowest-direct` resolutions to keep both ends of the supported range honest.

## Changes

### Runtime dependency policy (`pyproject.toml`, `.github/workflows/lint-and-test.yml`)

* Loosen runtime ranges: `httpx==0.28.1` → `httpx>=0.28,<1`, `pydantic==2.13.3` → `pydantic>=2.13,<3` so consumers can resolve a single shared version with their other deps (dev/test/docs groups stay exactly pinned for reproducibility)
* Add a resolution matrix to the `test` job: `[highest, lowest-direct]` with `fail-fast: false` so breakage at either end of the supported range is caught
* Split the test step into unit (`-m "not integration"`) and integration (`-m integration`) runs; integration tests, coverage XML generation, and the DeepSource coverage upload only run on `highest` to avoid burning the live-API rate-limit budget twice

### Sphinx user guide & API reference rework (`_docs/sphinx/`)

* `getting-started.md`: rewrite the install / authentication / first-request flow against the real `LiquipediaClient` surface (resource attributes, `paginate()`, `**filters`, `ApiResponse`)
* `examples.md`: replace stale snippets with runnable examples covering all 16 resources, keyword filters, pagination, and error handling against the real exception hierarchy
* `api/client.rst`, `api/resources.rst`, `api/models.rst`, `api/exceptions.rst`, `api/response.rst`: align autodoc directives with the current module layout — every public class is documented, private bases (`_LpdbModel`, `_TeamTemplateBase`) are excluded, and resource pages now reflect the `Resource` / `TeamTemplateResource` / `TeamTemplateListResource` split

### Theme-aware documentation favicon (`_docs/sphinx/conf.py`, `_docs/sphinx/_templates/page.html`, `_docs/sphinx/_static/`)

* Add `database-search.svg` (light) and `database-search-dark.svg` (dark) to `_static/`
* Wire `html_static_path` and `html_favicon` in `conf.py` for the default (light) icon
* Override Furo's `extrahead` block in `_templates/page.html` to swap to the dark variant via `media="(prefers-color-scheme: dark)"`

### Tooling hygiene (`.gitignore`)

* Ignore `.remember/` so the Remember plugin's local state stays out of the repo

## Validation steps before merge

- [x] Lint & Test CI OK (no regression)
- [x] DeepSource health check OK (no regression)
- [x] Human review completed (post-changes made by DeepSource or automated tools)