### PR TITLE
fix(release): trigger v0.1.1 with loosened runtime ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Loosen runtime dependency ranges to `httpx >=0.28,<1` and `pydantic >=2.13,<3` so consumers can resolve a single
+  shared version alongside their other deps; CI now runs the test suite against both `highest` and `lowest-direct`
+  resolutions
+- Treat `build:` Conventional Commit prefix as patch-level release trigger in `python-semantic-release` config so
+  dependency-policy commits cut a release without manual tagging
 - Replace hardcoded version assertion in `test_version_value` with semver format regex check
 - Replace relative file links with absolute GitHub URLs in README and CONTRIBUTING to fix broken links on PyPI
 - Reformat README title heading

--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ with LiquipediaClient("my-app", api_key="your-api-key") as client:
         match = Match.model_validate(record)
         print(match.match2id, match.date, match.winner)
 
-    # Keyword filters — no need to write raw LPDB conditions
+    # Keyword filters — no need to write raw LPDB conditions.
+    # Operator prefixes (`!`, `<`, `>`) pass through, so `earnings=">10000"` becomes `[[earnings::>10000]]`.
     response = client.players.list("rocketleague", pagename="Zen")
 
     # Match-specific parameters (stream data)

--- a/_docs/ROADMAP.md
+++ b/_docs/ROADMAP.md
@@ -139,7 +139,16 @@ First PyPI release covering the full LPDB v3 surface.
     - Bumps version in `pyproject.toml`, `__init__.py`, and `_client.py` automatically
     - Commits, tags, and creates GitHub Release → triggers existing `publish.yml` → PyPI
     - `CHANGELOG.md` remains manually maintained (not managed by PSR)
-- [ ] conda-forge package (submit recipe to `conda-forge/staged-recipes`, auto-rebuilds on PyPI releases)
+    - `patch_tags = ["fix", "perf", "build"]` so dependency-policy commits trigger a patch release
+      without manual tagging
+- [x] Loosen runtime dependency ranges (`httpx >=0.28,<1`, `pydantic >=2.13,<3`) so consumers can resolve a single
+  shared version alongside their other deps; `lint-and-test.yml` runs the test suite against both `highest` and
+  `lowest-direct` resolutions
+- [x] Theme-aware Lucide favicon for the docs site (`database-search.svg` light + `-dark.svg`, wired through
+  `html_favicon` in `conf.py` and a `prefers-color-scheme: dark` `<link>` in `_templates/page.html`)
+- [ ] conda-forge package — recipe submitted to `conda-forge/staged-recipes#33215`; awaiting v0.1.1 on PyPI to resolve a
+  `pip check` mismatch (v0.1.0 sdist still declares the old strict pins). After merge the feedstock auto-rebuilds on
+  PyPI releases via `regro-cf-autotick-bot`
 
 ## Future / Out of scope for v1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,4 +156,4 @@ token = { env = "GH_TOKEN" }
 [tool.semantic_release.commit_parser_options]
 allowed_tags = ["feat", "fix", "perf", "refactor", "docs", "style", "test", "build", "ci", "chore"]
 minor_tags = ["feat"]
-patch_tags = ["fix", "perf"]
+patch_tags = ["fix", "perf", "build"]


### PR DESCRIPTION
## Description

Cut v0.1.1 to ship the loosened runtime ranges (`httpx >=0.28,<1`, `pydantic >=2.13,<3`) merged in #15, and adjust the release config so future `build:` commits don't get stuck.

The conda-forge submission (conda-forge/staged-recipes#33215) is currently failing `pip check` because the on-PyPI v0.1.0 metadata still declares the old `httpx==0.28.1` / `pydantic==2.12.5` strict pins, while the recipe was written against the new ranges. Once v0.1.1 lands on PyPI, the recipe will be bumped to match.

## Changes

- `pyproject.toml`: extend `[tool.semantic_release.commit_parser_options].patch_tags` from `["fix", "perf"]` to `["fix", "perf", "build"]`, so dependency-policy commits cut a patch release without a manual tag.
- `CHANGELOG.md`: capture the runtime-range loosening (Changed) and the PSR tag-set update (Changed) under `[Unreleased]`.
- This PR's own commit uses `fix:` so PSR triggers a patch release as soon as the change reaches `main`, independent of how PSR parses the multi-prefix squash from #15.

## Related issues

Unblocks conda-forge/staged-recipes#33215.

## Validation steps before merge

- [x] Lint & Test CI OK (no regression)
- [x] DeepSource health check OK (no regression)
- [x] Human review completed (post-changes made by DeepSource or automated tools)