### PR TITLE
docs(client): add docstring to _resolve_version helper

### DIFF
--- a/liquipydia/_client.py
+++ b/liquipydia/_client.py
@@ -38,6 +38,13 @@ from liquipydia._response import ApiResponse
 
 
 def _resolve_version() -> str:
+    """Resolve the installed package version for the User-Agent header.
+
+    Returns:
+        The version reported by ``importlib.metadata`` for the ``liquipydia`` distribution, or ``"0.0.0+unknown"`` if
+        the package is being run from a source tree without an installed distribution (e.g. ``PYTHONPATH``-based
+        imports during local dev or CI bootstrap).
+    """
     try:
         return _pkg_version("liquipydia")
     except PackageNotFoundError:


### PR DESCRIPTION
## Summary

Resolve a DeepSource finding on the `_resolve_version()` helper introduced in commit `96ae034` (PR #18). The helper had no docstring; this adds a Google-style one documenting the `importlib.metadata` lookup and the `PackageNotFoundError` fallback.

## Validation steps before merge

- [x] Lint & Test CI OK (no regression)
- [x] DeepSource health check OK (no regression)
- [x] Human review completed (post-changes made by DeepSource or automated tools)