### PR TITLE
Post-v0.1.2 housekeeping: close out changelog, retarget conda-forge recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2] - 2026-05-04
+
 ### Changed
 
 - Resolve `_client.py:_VERSION` via `importlib.metadata.version("liquipydia")` at import time instead of duplicating
   the literal in source. The `version_variables` entry for `_client.py` is dropped from the
   `python-semantic-release` config — only `pyproject.toml` and `liquipydia/__init__.py` need to be bumped now, and the
   User-Agent header always reflects the actual installed package version
+- Add a Google-style docstring to the new `_resolve_version()` helper documenting the `importlib.metadata` lookup and
+  the `PackageNotFoundError` → `"0.0.0+unknown"` fallback
 
 ### Fixed
 
@@ -213,7 +217,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `.gitattributes` with LF line ending normalization
 - `CHANGELOG.md` (this file)
 
-[Unreleased]: https://github.com/Dyl-M/liquipydia/compare/v0.1.1...dev
+[Unreleased]: https://github.com/Dyl-M/liquipydia/compare/v0.1.2...dev
+
+[0.1.2]: https://github.com/Dyl-M/liquipydia/compare/v0.1.1...v0.1.2
 
 [0.1.1]: https://github.com/Dyl-M/liquipydia/compare/v0.1.0...v0.1.1
 

--- a/_docs/ROADMAP.md
+++ b/_docs/ROADMAP.md
@@ -146,9 +146,9 @@ First PyPI release covering the full LPDB v3 surface.
   `lowest-direct` resolutions
 - [x] Theme-aware Lucide favicon for the docs site (`database-search.svg` light + `-dark.svg`, wired through
   `html_favicon` in `conf.py` and a `prefers-color-scheme: dark` `<link>` in `_templates/page.html`)
-- [ ] conda-forge package — recipe submitted to `conda-forge/staged-recipes#33215`; recipe bumped to v0.1.1 on
-  2026-05-04 once the loosened-pin sdist landed on PyPI. Awaiting conda-forge maintainer review and merge; after merge
-  the feedstock auto-rebuilds on PyPI releases via `regro-cf-autotick-bot`
+- [ ] conda-forge package — recipe submitted to `conda-forge/staged-recipes#33215`; recipe bumped to v0.1.2 on
+  2026-05-04 to skip the v0.1.1 User-Agent regression so the first conda release ships clean. Awaiting conda-forge
+  maintainer review and merge; after merge the feedstock auto-rebuilds on PyPI releases via `regro-cf-autotick-bot`
 
 ## Future / Out of scope for v1
 


### PR DESCRIPTION
## Summary

Routine post-release housekeeping after `v0.1.2` shipped to PyPI on 2026-05-04. No code changes — `pyproject.toml` and `liquipydia/__init__.py` are already at `0.1.2` (cherry-picked PSR bump from main onto dev in commit `32a0230`). This branch only updates the changelog and the conda-forge roadmap entry.

## Changes

### Close out v0.1.2 in `CHANGELOG.md`

* Move the `[Unreleased]` entries — the `_resolve_version` helper / `version_variables` cleanup under `Changed` and the v0.1.1-wheel User-Agent regression under `Fixed` — into a new `[0.1.2] - 2026-05-04` section.
* Add the `_resolve_version` docstring change (resolved a DeepSource finding via PR #19) under `Changed` so v0.1.2 captures both PRs (#18 + #19) that contributed to the release.
* Register the `[0.1.2]: …compare/v0.1.1...v0.1.2` link and re-anchor `[Unreleased]` to `v0.1.2...dev`.

### Update `_docs/ROADMAP.md` for the conda-forge state

* Conda-forge item: recipe bumped on `Dyl-M/staged-recipes:liquipydia` (PR #33215) from v0.1.1 → v0.1.2 on 2026-05-04, retargeting the open submission so the first conda release skips the User-Agent-buggy v0.1.1 entirely. Now awaiting conda-forge maintainer review and merge.

## Out of scope

* No PSR trigger expected from this PR — `docs(changelog):` is not in `patch_tags`, and even if it were, this PR targets `dev`, not `main`. PSR only runs on push to `main`.
* No release-notes change. PSR auto-published `v0.1.2` notes when it ran on 2026-05-04 20:26:59 UTC; the staged hand-edited version is in `_drafts/RELEASE-DRAFT.md` for an out-of-band edit on the GitHub Release page if desired.

## Validation steps before merge

- [x] Lint & Test CI OK (no regression)
- [ ] DeepSource health check OK (no regression)
- [x] Human review completed (post-changes made by DeepSource or automated tools)
